### PR TITLE
always store strings as text, don't use immutable strings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ State tracking:
   name: string;
   extension: string;
   mimeType: string;
-  content: ImmutableString | Uint8Array;
+  content: string | Uint8Array;
   metadata: {
     permissions: number;
   };

--- a/src/core/change-detection.ts
+++ b/src/core/change-detection.ts
@@ -411,12 +411,7 @@ export class ChangeDetector {
     const handle = await this.repo.find<FileDocument>(url);
     const doc = await handle.view(heads).doc();
 
-    const content = (doc as FileDocument | undefined)?.content;
-    // Convert ImmutableString to regular string
-    if (A.isImmutableString(content)) {
-      return content.toString();
-    }
-    return content as string | Uint8Array;
+    return (doc as FileDocument | undefined)?.content ?? null;
   }
 
   /**
@@ -432,12 +427,7 @@ export class ChangeDetector {
       if (!doc) return null;
 
       const fileDoc = doc as FileDocument;
-      const content = fileDoc.content;
-      // Convert ImmutableString to regular string
-      if (A.isImmutableString(content)) {
-        return content.toString();
-      }
-      return content as string | Uint8Array;
+      return fileDoc.content;
     } catch (error) {
       out.taskLine(`Failed to get remote content: ${error}`, true);
       return null;

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -554,11 +554,7 @@ export class SyncEngine {
 
           // If new content is provided, update it (handles move + modification case)
           if (move.newContent !== undefined) {
-            if (typeof move.newContent === "string") {
-              doc.content = new A.ImmutableString(move.newContent);
-            } else {
-              doc.content = move.newContent;
-            }
+            doc.content = move.newContent;
           }
         });
       } else {
@@ -567,11 +563,7 @@ export class SyncEngine {
 
           // If new content is provided, update it (handles move + modification case)
           if (move.newContent !== undefined) {
-            if (typeof move.newContent === "string") {
-              doc.content = new A.ImmutableString(move.newContent);
-            } else {
-              doc.content = move.newContent;
-            }
+            doc.content = move.newContent;
           }
         });
       }
@@ -612,11 +604,7 @@ export class SyncEngine {
       name: change.path.split("/").pop() || "",
       extension: getFileExtension(change.path),
       mimeType: getEnhancedMimeType(change.path),
-      content: isText
-        ? new A.ImmutableString("")
-        : typeof change.localContent === "string"
-        ? new A.ImmutableString(change.localContent)
-        : change.localContent, // Empty ImmutableString for text, wrap strings for safety, actual content for binary
+      content: change.localContent,
       metadata: {
         permissions: 0o644,
       },
@@ -624,10 +612,10 @@ export class SyncEngine {
 
     const handle = this.repo.create(fileDoc);
 
-    // For text files, use ImmutableString for better performance
+    // For text files, set the actual content
     if (isText && typeof change.localContent === "string") {
       handle.change((doc: FileDocument) => {
-        doc.content = new A.ImmutableString(change.localContent as string);
+        doc.content = change.localContent as string;
       });
     }
 
@@ -678,11 +666,7 @@ export class SyncEngine {
     }
 
     handle.changeAt(heads, (doc: FileDocument) => {
-      if (typeof content === "string") {
-        doc.content = new A.ImmutableString(content);
-      } else {
-        doc.content = content;
-      }
+      doc.content = content;
     });
 
     // Update snapshot with new heads after content change
@@ -716,11 +700,11 @@ export class SyncEngine {
     }
     if (heads) {
       handle.changeAt(heads, (doc: FileDocument) => {
-        doc.content = new A.ImmutableString("");
+        doc.content = "";
       });
     } else {
       handle.change((doc: FileDocument) => {
-        doc.content = new A.ImmutableString("");
+        doc.content = "";
       });
     }
   }

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -1,5 +1,4 @@
 import { AutomergeUrl, UrlHeads } from "@automerge/automerge-repo";
-import * as A from "@automerge/automerge";
 
 /**
  * Entry in a directory document
@@ -27,7 +26,7 @@ export interface FileDocument {
   name: string;
   extension: string;
   mimeType: string;
-  content: A.ImmutableString | Uint8Array;
+  content: string | Uint8Array;
   metadata: {
     permissions: number;
   };

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -4,7 +4,6 @@ import * as crypto from "crypto";
 import { glob } from "glob";
 import * as mimeTypes from "mime-types";
 import * as ignore from "ignore";
-import * as A from "@automerge/automerge";
 import { FileSystemEntry, FileType } from "../types";
 import { isEnhancedTextFile } from "./mime-types";
 
@@ -96,15 +95,12 @@ export async function readFileContent(
  */
 export async function writeFileContent(
   filePath: string,
-  content: string | A.ImmutableString | Uint8Array
+  content: string | Uint8Array
 ): Promise<void> {
   await ensureDirectoryExists(path.dirname(filePath));
 
   if (typeof content === "string") {
     await fs.writeFile(filePath, content, "utf8");
-  } else if (A.isImmutableString(content)) {
-    // Convert ImmutableString to regular string for filesystem operations
-    await fs.writeFile(filePath, content.toString(), "utf8");
   } else {
     await fs.writeFile(filePath, content);
   }
@@ -232,14 +228,10 @@ export async function movePath(
  * Calculate content hash for change detection
  */
 export async function calculateContentHash(
-  content: string | A.ImmutableString | Uint8Array
+  content: string | Uint8Array
 ): Promise<string> {
   const hash = crypto.createHash("sha256");
-  if (A.isImmutableString(content)) {
-    hash.update(content.toString());
-  } else {
-    hash.update(content);
-  }
+  hash.update(content);
   return hash.digest("hex");
 }
 


### PR DESCRIPTION
It's really annoying that all text files are stored as immutable text by default. What if we always stored strings as text again? 

If this is not feasible I think we should add an option to configure specific folders as immutable strings but maybe this is good enough