### PR TITLE
Explicitely handle zero-sized files

### DIFF
--- a/src/core/change-detection.ts
+++ b/src/core/change-detection.ts
@@ -410,7 +410,7 @@ export class ChangeDetector {
 						const remoteContent = await this.getCurrentRemoteContent(entry.url)
 						const remoteHead = await this.getCurrentRemoteHead(entry.url)
 
-						if (localContent && remoteContent) {
+						if (localContent !== null && remoteContent !== null) {
 							// File exists both locally and remotely but not in snapshot
 							changes.push({
 								path: entryPath,
@@ -643,7 +643,7 @@ export class ChangeDetector {
 	private async getFileTypeFromContent(
 		content: string | Uint8Array | null
 	): Promise<FileType> {
-		if (!content) return FileType.TEXT
+		if (content === null) return FileType.TEXT
 
 		if (content instanceof Uint8Array) {
 			return FileType.BINARY

--- a/src/core/move-detection.ts
+++ b/src/core/move-detection.ts
@@ -101,7 +101,9 @@ export class MoveDetector {
       typeof content1 === "string" ? content1.length : content1.length;
     const size2 =
       typeof content2 === "string" ? content2.length : content2.length;
-    const sizeDiff = Math.abs(size1 - size2) / Math.max(size1, size2);
+    const maxSize = Math.max(size1, size2);
+    if (maxSize === 0) return 1.0;
+    const sizeDiff = Math.abs(size1 - size2) / maxSize;
     if (sizeDiff > 0.5) return 0.0;
 
     // Binary files: hash mismatch = not a move

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -16,7 +16,7 @@ export function isContentEqual(
   content2: string | Uint8Array | null
 ): boolean {
   if (content1 === content2) return true;
-  if (!content1 || !content2) return false;
+  if (content1 === null || content2 === null) return false;
 
   if (typeof content1 !== typeof content2) return false;
 


### PR DESCRIPTION
Presently, files with no content (e.g. `touch foo.txt`) fail to ingest correctly (reported by Warth and PvH, reproduced by me). There is some logic to check for these cases, but notably use truthy values, which behave incorrectly for `""` and `0`. This PR fixes several such sites.