### PR TITLE
Switch from `=== null` to `== null`

### DIFF
--- a/src/core/change-detection.ts
+++ b/src/core/change-detection.ts
@@ -410,7 +410,7 @@ export class ChangeDetector {
 						const remoteContent = await this.getCurrentRemoteContent(entry.url)
 						const remoteHead = await this.getCurrentRemoteHead(entry.url)
 
-						if (localContent !== null && remoteContent !== null) {
+						if (localContent != null && remoteContent == null) {
 							// File exists both locally and remotely but not in snapshot
 							changes.push({
 								path: entryPath,
@@ -643,7 +643,7 @@ export class ChangeDetector {
 	private async getFileTypeFromContent(
 		content: string | Uint8Array | null
 	): Promise<FileType> {
-		if (content === null) return FileType.TEXT
+		if (content == null) return FileType.TEXT
 
 		if (content instanceof Uint8Array) {
 			return FileType.BINARY

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -16,7 +16,7 @@ export function isContentEqual(
   content2: string | Uint8Array | null
 ): boolean {
   if (content1 === content2) return true;
-  if (content1 === null || content2 === null) return false;
+  if (content1 == null || content2 == null) return false;
 
   if (typeof content1 !== typeof content2) return false;
 


### PR DESCRIPTION
From` a chat with Chee. We may as well also account for `undefined` in case upstream changes the representation, and we don't currently depend on `null` explicitly 