### PR TITLE
Fix stale diff for existing workspaces

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -436,8 +436,8 @@ export async function diff(
 ): Promise<void> {
   out.task("Analyzing changes");
 
-  const { repo, syncEngine } = await setupCommandContext(targetPath, { syncEnabled: false });
-  const preview = await syncEngine.previewChanges();
+	const { repo, syncEngine } = await setupCommandContext(targetPath);
+	const preview = await syncEngine.previewChanges();
 
   out.done();
 
@@ -445,6 +445,7 @@ export async function diff(
     for (const change of preview.changes) {
       out.log(change.path);
     }
+    await safeRepoShutdown(repo);
     return;
   }
 

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -453,54 +453,7 @@ export class SyncEngine {
 
 			debug(`sync: rootDirectoryUrl=${snapshot.rootDirectoryUrl}, files=${snapshot.files.size}, dirs=${snapshot.directories.size}`)
 
-			// Wait for initial sync to receive any pending remote changes
-			if (this.config.sync_enabled && snapshot.rootDirectoryUrl) {
-				debug("sync: waiting for root document to be ready")
-				out.update("Waiting for root document from server")
-
-				// Wait for the root document to be fetched from the network.
-				// repo.find() rejects with "unavailable" if the server doesn't
-				// have the document yet, so we retry with backoff.
-				// This is critical for clone scenarios.
-				const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
-				const maxAttempts = 6
-				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-					try {
-						const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
-						rootHandle.doc() // throws if not ready
-						debug(`sync: root document ready (attempt ${attempt})`)
-						break
-					} catch (error) {
-						const isUnavailable = String(error).includes("unavailable") || String(error).includes("not ready")
-						if (isUnavailable && attempt < maxAttempts) {
-							const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000)
-							debug(`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`)
-							out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
-							await new Promise(r => setTimeout(r, delay))
-						} else {
-							debug(`sync: root document unavailable after ${maxAttempts} attempts: ${error}`)
-							out.taskLine(`Root document unavailable: ${error}`, true)
-							break
-						}
-					}
-				}
-
-				debug("sync: waiting for initial bidirectional sync")
-				out.update("Waiting for initial sync from server")
-				try {
-					await waitForBidirectionalSync(
-						this.repo,
-						snapshot.rootDirectoryUrl,
-						{
-							timeoutMs: 5000, // Increased timeout for initial sync
-							pollIntervalMs: 100,
-							stableChecksRequired: 3,
-						}
-					)
-				} catch (error) {
-					out.taskLine(`Initial sync: ${error}`, true)
-				}
-			}
+			await this.refreshRemoteState(snapshot)
 
 			// Detect all changes
 			debug("sync: detecting changes")
@@ -1765,6 +1718,12 @@ export class SyncEngine {
 			}
 		}
 
+		try {
+			await this.refreshRemoteState(snapshot, {bestEffort: true})
+		} catch {
+			// Best-effort refresh: preview should still work from local state.
+		}
+
 		const changes = await this.changeDetector.detectChanges(snapshot)
 		const {moves} = await this.moveDetector.detectMoves(changes, snapshot)
 
@@ -1857,6 +1816,130 @@ export class SyncEngine {
 		} catch (error) {
 			// Failed to update root directory timestamp
 		}
+	}
+
+	private async refreshRemoteState(
+		snapshot: SyncSnapshot,
+		options: {bestEffort?: boolean} = {}
+	): Promise<void> {
+		if (!this.config.sync_enabled || !snapshot.rootDirectoryUrl) {
+			return
+		}
+
+		const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
+		const bestEffort = options.bestEffort ?? false
+		const maxAttempts = bestEffort ? 2 : 6
+
+		debug("sync: waiting for root document to be ready")
+		out.update("Waiting for root document from server")
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
+				rootHandle.doc()
+				debug(`sync: root document ready (attempt ${attempt})`)
+				break
+			} catch (error) {
+				const isUnavailable =
+					String(error).includes("unavailable") ||
+					String(error).includes("not ready")
+				if (isUnavailable && attempt < maxAttempts) {
+					const delay = bestEffort
+						? Math.min(250 * Math.pow(2, attempt - 1), 500)
+						: Math.min(1000 * Math.pow(2, attempt - 1), 10000)
+					debug(
+						`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`
+					)
+					out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
+					await new Promise(r => setTimeout(r, delay))
+				} else {
+					if (bestEffort && isUnavailable) {
+						debug(
+							`sync: root document unavailable after ${attempt} attempts in best-effort mode`
+						)
+						return
+					}
+					debug(
+						`sync: root document unavailable after ${maxAttempts} attempts: ${error}`
+					)
+					out.taskLine(`Root document unavailable: ${error}`, true)
+					break
+				}
+			}
+		}
+
+		debug("sync: waiting for initial bidirectional sync")
+		out.update("Waiting for initial sync from server")
+		try {
+			await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+				timeoutMs: 5000,
+				pollIntervalMs: 100,
+				stableChecksRequired: 3,
+			})
+		} catch (error) {
+			out.taskLine(`Initial sync: ${error}`, true)
+		}
+
+		const trackedHandles: DocHandle<unknown>[] = []
+		const trackedUrls = new Set<AutomergeUrl>()
+		trackedUrls.add(plainRootUrl)
+		for (const entry of snapshot.directories.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+		for (const entry of snapshot.files.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+
+		for (const url of trackedUrls) {
+			try {
+				const handle = await this.repo.find(url)
+				handle.doc()
+				trackedHandles.push(handle)
+			} catch {
+				// Change detection will retry unavailable documents.
+			}
+		}
+
+		if (trackedHandles.length === 0) {
+			return
+		}
+
+		debug(
+			`sync: refreshing ${trackedHandles.length} tracked documents before change detection`
+		)
+		out.update(`Refreshing ${trackedHandles.length} tracked documents`)
+
+		const storageId = this.config.subduction
+			? undefined
+			: this.config.sync_server_storage_id
+		const syncTimeoutMs = Number(process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? 60000)
+
+		if (storageId) {
+			await waitForSync(trackedHandles, storageId, syncTimeoutMs)
+			for (const handle of trackedHandles) {
+				const syncInfo = handle.getSyncInfo(storageId as never)
+				const remoteHeads = syncInfo?.lastHeads
+				if (!remoteHeads || A.equals(remoteHeads, handle.heads())) {
+					continue
+				}
+
+				const {documentId} = parseAutomergeUrl(handle.url)
+				const remoteUrl = stringifyAutomergeUrl({documentId, heads: remoteHeads})
+				try {
+					await this.repo.find(remoteUrl)
+				} catch {
+					// Fall back to the current local handle state if remote materialization fails.
+				}
+			}
+			return
+		}
+
+		await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+			timeoutMs: BIDIRECTIONAL_SYNC_TIMEOUT_MS,
+			pollIntervalMs: 100,
+			stableChecksRequired: 3,
+			handles: trackedHandles,
+		})
 	}
 
 }

--- a/test/integration/existing-workspace-diff.test.ts
+++ b/test/integration/existing-workspace-diff.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as tmp from "tmp";
+
+const execFilePromise = promisify(execFile);
+const PUSHWORK_CLI = path.join(__dirname, "../../dist/cli.js");
+
+async function pushwork(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFilePromise("node", [PUSHWORK_CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        PUSHWORK_SYNC_TIMEOUT_MS: process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? "5000",
+        PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS:
+          process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? "2000",
+        PUSHWORK_SYNC_GRACE_MS: process.env.PUSHWORK_SYNC_GRACE_MS ?? "0",
+      },
+    });
+  } catch (error: any) {
+    throw new Error(
+      `pushwork ${args.join(" ")} failed: ${error.message}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+    );
+  }
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+describe("Existing-workspace diff", () => {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = tmpObj.name;
+    cleanup = tmpObj.removeCallback;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows remote-only tracked file changes in an existing clone", async () => {
+    const repoA = path.join(tmpDir, "repo-a");
+    const repoB = path.join(tmpDir, "repo-b");
+    const repoObserver = path.join(tmpDir, "repo-observer");
+    await fs.mkdir(repoA);
+    await fs.mkdir(repoB);
+    await fs.mkdir(repoObserver);
+
+    await fs.writeFile(path.join(repoA, "hello.md"), "hello\n");
+    await pushwork(["init", "."], repoA);
+
+    const { stdout: rootUrl } = await pushwork(["url"], repoA);
+    await pushwork(["clone", rootUrl.trim(), repoB], tmpDir);
+
+    await fs.mkdir(path.join(repoA, "alpha"));
+    await fs.writeFile(path.join(repoA, "alpha", "second.md"), "second file\n");
+    await pushwork(["sync", "--gentle"], repoA);
+
+    await pushwork(["clone", rootUrl.trim(), repoObserver], tmpDir);
+    expect(await readFile(path.join(repoObserver, "alpha", "second.md"))).toBe(
+      "second file\n",
+    );
+
+    const diffOutput = (await pushwork(["diff"], repoB)).stdout;
+    expect(diffOutput).not.toContain("No changes detected");
+    expect(diffOutput).toContain("[remote] alpha/second.md");
+    expect(diffOutput).toContain("alpha/second.md");
+  }, 60_000);
+
+  it("still shows local diffs when the sync server is unreachable", async () => {
+    const repo = path.join(tmpDir, "repo-offline");
+    await fs.mkdir(repo);
+
+    const previousSyncTimeout = process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+    const previousBidirectionalTimeout = process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+    process.env.PUSHWORK_SYNC_TIMEOUT_MS = "1000";
+    process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = "500";
+
+    try {
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\n");
+      await pushwork(["init", "."], repo);
+
+      const configPath = path.join(repo, ".pushwork", "config.json");
+      const config = JSON.parse(await readFile(configPath));
+      config.sync_server = "ws://127.0.0.1:1";
+      config.sync_server_storage_id = "00000000-0000-0000-0000-000000000000";
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\nlocal change\n");
+
+      const diffOutput = (await pushwork(["diff"], repo)).stdout;
+      expect(diffOutput).not.toContain("No changes detected");
+      expect(diffOutput).toContain("[local]  hello.md");
+      expect(diffOutput).toContain("local change");
+    } finally {
+      if (previousSyncTimeout === undefined) {
+        delete process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_SYNC_TIMEOUT_MS = previousSyncTimeout;
+      }
+
+      if (previousBidirectionalTimeout === undefined) {
+        delete process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = previousBidirectionalTimeout;
+      }
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary
- add a focused regression test showing that an existing clone can still see remote-only tracked changes after another peer syncs them
- keep `pushwork diff` usable when the sync server is unreachable by bounding best-effort refresh work and falling back to local diffing
- shut the repo down on the `--name-only` early-return path so the CLI does not hang after printing results

## Test intent
The regression simulates a long-lived collaborator: peer A initialises a workspace, peer B clones it, peer A adds a tracked file and syncs, and a fresh observer cloned afterwards can read the new file, but peer B's `pushwork diff` insists "No changes detected." 

Arguably the intent of pushwork diff is your local changes vs your synced changes, but to me it feels weird that we don't detect remote changes on pushwork diff. I would expect to see my local file vs remote up to date changes.

## Testing
- pnpm run build
- pnpm exec jest test/integration/existing-workspace-diff.test.ts --runInBand