### PR TITLE
Accept sync --sub for compatibility

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -189,6 +189,7 @@ program
     "Recreate all Automerge documents from scratch",
     false
   )
+  .addOption(new Option("--sub", "Accepted for backwards compatibility").default(false).hideHelp())
   .addOption(new Option("-f, --force", "Accepted for backwards compatibility").default(false).hideHelp())
   .option("-v, --verbose", "Verbose output", false)
   .action(async (path, opts) => {


### PR DESCRIPTION
## Summary
- accept `--sub` on `sync` as a backwards-compatible no-op that continues using persisted config

## Background
Users who initialised a workspace with `init --sub` and then ran `sync --sub` in scripts or muscle memory were getting `unknown option '--sub'` even though the workspace was already configured for Subduction. This restores the previously supported invocation without changing semantics — `sync` continues to use the backend persisted in `.pushwork/config.json`. The `--sub` flag on `sync` is intentionally hidden from `--help` so it does not suggest an override that doesn't exist.