### PR TITLE
Fix concurrent same-file sync

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -436,8 +436,8 @@ export async function diff(
 ): Promise<void> {
   out.task("Analyzing changes");
 
-  const { repo, syncEngine } = await setupCommandContext(targetPath, { syncEnabled: false });
-  const preview = await syncEngine.previewChanges();
+	const { repo, syncEngine } = await setupCommandContext(targetPath);
+	const preview = await syncEngine.previewChanges();
 
   out.done();
 
@@ -445,6 +445,7 @@ export async function diff(
     for (const change of preview.changes) {
       out.log(change.path);
     }
+    await safeRepoShutdown(repo);
     return;
   }
 

--- a/src/core/change-detection.ts
+++ b/src/core/change-detection.ts
@@ -56,24 +56,55 @@ export class ChangeDetector {
 	 * Detect all changes between local filesystem and snapshot
 	 */
 	async detectChanges(snapshot: SyncSnapshot, excludePaths?: Set<string>): Promise<DetectedChange[]> {
-		const changes: DetectedChange[] = []
-
 		// Get current filesystem state
 		const currentFiles = await this.getCurrentFilesystemState()
 
 		// Check for local changes (new, modified, deleted files)
 		const localChanges = await this.detectLocalChanges(snapshot, currentFiles)
-		changes.push(...localChanges)
 
 		// Check for remote changes (changes in Automerge documents)
 		const remoteChanges = await this.detectRemoteChanges(snapshot)
-		changes.push(...remoteChanges)
 
 		// Check for new remote documents not in snapshot (critical for clone scenarios)
 		const newRemoteDocuments = await this.detectNewRemoteDocuments(snapshot, excludePaths)
-		changes.push(...newRemoteDocuments)
 
-		return changes
+		const changesByPath = new Map<string, DetectedChange>()
+		for (const change of [...localChanges, ...remoteChanges, ...newRemoteDocuments]) {
+			const existing = changesByPath.get(change.path)
+			if (!existing) {
+				changesByPath.set(change.path, change)
+				continue
+			}
+
+			changesByPath.set(change.path, {
+				...existing,
+				changeType: this.mergeChangeTypes(existing.changeType, change.changeType),
+				localContent:
+					existing.localContent !== null ? existing.localContent : change.localContent,
+				remoteContent:
+					change.remoteContent !== null ? change.remoteContent : existing.remoteContent,
+				localHead: existing.localHead ?? change.localHead,
+				remoteHead: change.remoteHead ?? existing.remoteHead,
+			})
+		}
+
+		return Array.from(changesByPath.values())
+	}
+
+	private mergeChangeTypes(a: ChangeType, b: ChangeType): ChangeType {
+		if (a === b) return a
+		if (a === ChangeType.BOTH_CHANGED || b === ChangeType.BOTH_CHANGED) {
+			return ChangeType.BOTH_CHANGED
+		}
+		if (a === ChangeType.NO_CHANGE) return b
+		if (b === ChangeType.NO_CHANGE) return a
+		if (
+			(a === ChangeType.LOCAL_ONLY && b === ChangeType.REMOTE_ONLY) ||
+			(a === ChangeType.REMOTE_ONLY && b === ChangeType.LOCAL_ONLY)
+		) {
+			return ChangeType.BOTH_CHANGED
+		}
+		return b
 	}
 
 	/**
@@ -272,16 +303,9 @@ export class ChangeDetector {
 						return
 					}
 
-					// Check if the document was replaced entirely (new URL).
-					// This happens when a peer replaces an artifact file, fixes a
-					// legacy immutable string, or recreates a failed document.
-					// The old snapshot URL is now orphaned — read from the new one.
-					const urlReplaced = getPlainUrl(remoteEntry.url) !== getPlainUrl(snapshotEntry.url)
-					const remoteUrl = urlReplaced ? remoteEntry.url : snapshotEntry.url
+					const currentRemoteHead = await this.getCurrentRemoteHead(snapshotEntry.url)
 
-					const currentRemoteHead = await this.getCurrentRemoteHead(remoteUrl)
-
-					if (urlReplaced || !A.equals(currentRemoteHead, snapshotEntry.head)) {
+					if (!A.equals(currentRemoteHead, snapshotEntry.head)) {
 						if (this.isArtifactPath(relativePath)) {
 							// Artifact: skip content reads, just report head change
 							const localContent = await this.getLocalContent(relativePath)
@@ -296,20 +320,17 @@ export class ChangeDetector {
 								remoteContent: null,
 								localHead: snapshotEntry.head,
 								remoteHead: currentRemoteHead,
-								...(urlReplaced ? {remoteUrl: remoteEntry.url} : {}),
 							})
 							return
 						}
 
 						// Remote document has changed
-						const currentRemoteContent = await this.getCurrentRemoteContent(remoteUrl)
+						const currentRemoteContent = await this.getCurrentRemoteContent(snapshotEntry.url)
 						const localContent = await this.getLocalContent(relativePath)
-						const lastKnownContent = urlReplaced
-							? null // Can't diff against old doc when URL changed
-							: await this.getContentAtHead(
-								snapshotEntry.url,
-								snapshotEntry.head
-							)
+						const lastKnownContent = await this.getContentAtHead(
+							snapshotEntry.url,
+							snapshotEntry.head
+						)
 
 						const localChanged = localContent && lastKnownContent
 							? !isContentEqual(localContent, lastKnownContent)
@@ -327,7 +348,6 @@ export class ChangeDetector {
 							remoteContent: currentRemoteContent,
 							localHead: snapshotEntry.head,
 							remoteHead: currentRemoteHead,
-							...(urlReplaced ? {remoteUrl: remoteEntry.url} : {}),
 						})
 					}
 				}
@@ -440,43 +460,6 @@ export class ChangeDetector {
 								remoteHead,
 							})
 						}
-					// Only ignore if neither local nor remote content exists (ghost entry)
-				} else if (
-					getPlainUrl(entry.url) !== getPlainUrl(existingEntry.url)
-				) {
-					// HACK: URL replacement detection bolted onto the "discover new docs" walk.
-					//
-					// A peer can replace a document entirely (creating a new URL) rather than mutating
-					// the existing one. This happens in several cases in updateRemoteFile(): artifact
-					// paths are always replaced; non-artifact docs with legacy immutable string content
-					// are also replaced; and recreateFailedDocuments() replaces docs that timed out
-					// during network sync. The two normal remote-change scans both miss this:
-					//   - detectRemoteChanges() is snapshot-centric: it checks the old (now orphaned)
-					//     doc's heads, which haven't changed, so it reports no change.
-					//   - The "new doc" branch above is directory-centric: it skips paths already in
-					//     the snapshot, assuming they're handled by detectRemoteChanges().
-					//
-					// A cleaner fix would be to have detectRemoteChanges() also verify that the
-					// directory still points to the same URL for each snapshot entry, treating a
-					// mismatch as a first-class URL-replacement change rather than a special case here.
-					const localContent = await this.getLocalContent(entryPath)
-						const remoteContent = await this.getCurrentRemoteContent(entry.url)
-						const remoteHead = await this.getCurrentRemoteHead(entry.url)
-
-						if (remoteContent !== null) {
-							changes.push({
-								path: entryPath,
-								changeType:
-									localContent !== null
-										? ChangeType.BOTH_CHANGED
-										: ChangeType.REMOTE_ONLY,
-								fileType: await this.getFileTypeFromContent(remoteContent),
-								localContent: localContent ?? null,
-								remoteContent,
-								remoteHead,
-								remoteUrl: entry.url,
-							})
-						}
 					}
 				} else if (entry.type === "folder") {
 					// Recursively process subdirectory
@@ -559,17 +542,29 @@ export class ChangeDetector {
 		url: AutomergeUrl,
 		heads: UrlHeads
 	): Promise<string | Uint8Array | null> {
-		try {
-			// Strip heads for current document state
-			const plainUrl = getPlainUrl(url)
-			const handle = await this.repo.find<FileDocument>(plainUrl)
-			const doc = await handle.view(heads).doc()
+		const plainUrl = getPlainUrl(url)
 
-			const content = (doc as FileDocument | undefined)?.content
-			return readDocContent(content)
-		} catch {
-			return null
+		for (let attempt = 0; attempt < 5; attempt++) {
+			try {
+				const result = await this.findDocument<FileDocument>(plainUrl, {
+					maxRetries: 1,
+					retryDelayMs: 0,
+				})
+				if (!result) {
+					throw new Error("document unavailable")
+				}
+
+				const doc = await result.handle.view(heads).doc()
+				const content = (doc as FileDocument | undefined)?.content
+				return readDocContent(content)
+			} catch {
+				if (attempt < 4) {
+					await new Promise(r => setTimeout(r, 200 * (attempt + 1)))
+				}
+			}
 		}
+
+		return null
 	}
 
 	/**

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -30,6 +30,7 @@ import {
 	getPlainUrl,
 	updateTextContent,
 	readDocContent,
+	mergeTextWithBase,
 } from "../utils"
 import {isContentEqual, contentHash} from "../utils/content"
 import {waitForSync, waitForBidirectionalSync} from "../utils/network-sync"
@@ -121,7 +122,9 @@ export function nukeAndRebuildDocs(
 /**
  * Sync configuration constants
  */
-const BIDIRECTIONAL_SYNC_TIMEOUT_MS = 5000 // Timeout for bidirectional sync stability check
+const BIDIRECTIONAL_SYNC_TIMEOUT_MS = Number(
+	process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? 5000
+) // Timeout for bidirectional sync stability check
 
 /**
  * Bidirectional sync engine implementing two-phase sync
@@ -450,6 +453,8 @@ export class SyncEngine {
 			const snapshot =
 				(await this.snapshotManager.load()) ||
 				this.snapshotManager.createEmpty()
+			const sub = options?.sub ?? false
+			const storageId = sub ? undefined : this.config.sync_server_storage_id
 
 			debug(`sync: rootDirectoryUrl=${snapshot.rootDirectoryUrl}, files=${snapshot.files.size}, dirs=${snapshot.directories.size}`)
 
@@ -487,11 +492,9 @@ export class SyncEngine {
 
 			// Wait for network sync (important for clone scenarios)
 			if (this.config.sync_enabled) {
-				const sub = options?.sub ?? false
 				// In Subduction mode, pass no StorageId so waitForSync
 				// falls back to head-stability polling. In WebSocket mode,
 				// pass the StorageId for precise getSyncInfo-based verification.
-				const storageId = sub ? undefined : this.config.sync_server_storage_id
 
 				try {
 					// Ensure root directory handle is tracked for sync
@@ -1020,11 +1023,6 @@ export class SyncEngine {
 		if (snapshotEntry) {
 			// Update existing entry
 			snapshotEntry.head = change.remoteHead
-			// If the remote document was replaced (new URL), update the snapshot URL
-			if (change.remoteUrl) {
-				const fileHandle = await this.repo.find<FileDocument>(change.remoteUrl)
-				snapshotEntry.url = this.getEntryUrl(fileHandle, change.path)
-			}
 		} else {
 			// Create new snapshot entry for newly discovered remote file
 			// We need to find the remote file's URL from the directory hierarchy
@@ -1257,27 +1255,51 @@ export class SyncEngine {
 
 		const currentContent = readDocContent(rawContent)
 		const contentChanged = !isContentEqual(content, currentContent)
-
-		// Update snapshot heads even when content is identical
 		const snapshotEntry = snapshot.files.get(filePath)
-		if (snapshotEntry) {
-			// Update snapshot with current document heads
-			snapshot.files.set(filePath, {
-				...snapshotEntry,
-				head: handle.heads(),
-			})
-		}
+		const snapshotHeads = snapshotEntry?.head
+		const currentHeads = handle.heads()
+		const remoteChangedSinceSnapshot =
+			snapshotHeads != null && !A.equals(currentHeads, snapshotHeads)
 
 		if (!contentChanged) {
-			// Content is identical, but we've updated the snapshot heads above
-			// This prevents fresh change detection from seeing stale heads
+			if (snapshotEntry) {
+				// No local content delta remains to reconcile, so it's safe to
+				// advance the snapshot to the current remote heads immediately.
+				snapshot.files.set(filePath, {
+					...snapshotEntry,
+					head: currentHeads,
+				})
+			}
 			return
 		}
 
-		const heads = snapshotEntry?.head
+		const heads = snapshotHeads
 
 		if (!heads) {
 			throw new Error(`No heads found for ${url}`)
+		}
+
+		if (
+			remoteChangedSinceSnapshot &&
+			typeof content === "string" &&
+			typeof currentContent === "string"
+		) {
+			const baseDoc = await handle.view(heads).doc()
+			const baseContent = readDocContent(baseDoc?.content)
+
+			if (typeof baseContent === "string") {
+				const mergedContent = mergeTextWithBase(
+					baseContent,
+					content,
+					currentContent,
+				)
+
+				handle.change((doc: FileDocument) => {
+					updateTextContent(doc, ["content"], mergedContent)
+				})
+				this.handlesByPath.set(filePath, handle)
+				return
+			}
 		}
 
 		handle.changeAt(heads, (doc: FileDocument) => {
@@ -1288,8 +1310,10 @@ export class SyncEngine {
 			}
 		})
 
-		// Update snapshot with new heads after content change
-		if (snapshotEntry) {
+		// When the document changed remotely since our snapshot, keep the old
+		// snapshot heads until phase 2 so change re-detection still sees the
+		// merged remote state and pulls it back into the local workspace.
+		if (snapshotEntry && !remoteChangedSinceSnapshot) {
 			snapshot.files.set(filePath, {
 				...snapshotEntry,
 				head: handle.heads(),
@@ -1719,7 +1743,7 @@ export class SyncEngine {
 		}
 
 		try {
-			await this.refreshRemoteState(snapshot, {bestEffort: true})
+			await this.refreshRemoteState(snapshot)
 		} catch {
 			// Best-effort refresh: preview should still work from local state.
 		}
@@ -1818,21 +1842,44 @@ export class SyncEngine {
 		}
 	}
 
-	private async refreshRemoteState(
-		snapshot: SyncSnapshot,
-		options: {bestEffort?: boolean} = {}
-	): Promise<void> {
+	private async refreshTrackedHandles(
+		snapshot: SyncSnapshot
+	): Promise<DocHandle<unknown>[]> {
+		const urls = new Set<AutomergeUrl>()
+		if (snapshot.rootDirectoryUrl) {
+			urls.add(getPlainUrl(snapshot.rootDirectoryUrl))
+		}
+		for (const entry of snapshot.directories.values()) {
+			urls.add(getPlainUrl(entry.url))
+		}
+		for (const entry of snapshot.files.values()) {
+			urls.add(getPlainUrl(entry.url))
+		}
+
+		const handles: DocHandle<unknown>[] = []
+		for (const url of urls) {
+			const handle = await this.findReadyHandle(url)
+			if (handle) {
+				handles.push(handle)
+			}
+		}
+
+		return handles
+	}
+
+	private async refreshRemoteState(snapshot: SyncSnapshot): Promise<void> {
 		if (!this.config.sync_enabled || !snapshot.rootDirectoryUrl) {
 			return
 		}
 
-		const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
-		const bestEffort = options.bestEffort ?? false
-		const maxAttempts = bestEffort ? 2 : 6
+		const sub = this.config.subduction ?? false
+		const storageId = sub ? undefined : this.config.sync_server_storage_id
 
 		debug("sync: waiting for root document to be ready")
 		out.update("Waiting for root document from server")
 
+		const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
+		const maxAttempts = 6
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 			try {
 				const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
@@ -1844,21 +1891,13 @@ export class SyncEngine {
 					String(error).includes("unavailable") ||
 					String(error).includes("not ready")
 				if (isUnavailable && attempt < maxAttempts) {
-					const delay = bestEffort
-						? Math.min(250 * Math.pow(2, attempt - 1), 500)
-						: Math.min(1000 * Math.pow(2, attempt - 1), 10000)
+					const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000)
 					debug(
 						`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`
 					)
 					out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
 					await new Promise(r => setTimeout(r, delay))
 				} else {
-					if (bestEffort && isUnavailable) {
-						debug(
-							`sync: root document unavailable after ${attempt} attempts in best-effort mode`
-						)
-						return
-					}
 					debug(
 						`sync: root document unavailable after ${maxAttempts} attempts: ${error}`
 					)
@@ -1869,37 +1908,20 @@ export class SyncEngine {
 		}
 
 		debug("sync: waiting for initial bidirectional sync")
-		out.update("Waiting for initial sync from server")
-		try {
-			await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
-				timeoutMs: 5000,
-				pollIntervalMs: 100,
-				stableChecksRequired: 3,
-			})
-		} catch (error) {
-			out.taskLine(`Initial sync: ${error}`, true)
-		}
-
-		const trackedHandles: DocHandle<unknown>[] = []
-		const trackedUrls = new Set<AutomergeUrl>()
-		trackedUrls.add(plainRootUrl)
-		for (const entry of snapshot.directories.values()) {
-			trackedUrls.add(getPlainUrl(entry.url))
-		}
-		for (const entry of snapshot.files.values()) {
-			trackedUrls.add(getPlainUrl(entry.url))
-		}
-
-		for (const url of trackedUrls) {
+		if (snapshot.files.size === 0) {
+			out.update("Waiting for initial sync from server")
 			try {
-				const handle = await this.repo.find(url)
-				handle.doc()
-				trackedHandles.push(handle)
-			} catch {
-				// Change detection will retry unavailable documents.
+				await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+					timeoutMs: 5000,
+					pollIntervalMs: 100,
+					stableChecksRequired: 3,
+				})
+			} catch (error) {
+				out.taskLine(`Initial sync: ${error}`, true)
 			}
 		}
 
+		const trackedHandles = await this.refreshTrackedHandles(snapshot)
 		if (trackedHandles.length === 0) {
 			return
 		}
@@ -1908,29 +1930,9 @@ export class SyncEngine {
 			`sync: refreshing ${trackedHandles.length} tracked documents before change detection`
 		)
 		out.update(`Refreshing ${trackedHandles.length} tracked documents`)
-
-		const storageId = this.config.subduction
-			? undefined
-			: this.config.sync_server_storage_id
-		const syncTimeoutMs = Number(process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? 60000)
-
 		if (storageId) {
-			await waitForSync(trackedHandles, storageId, syncTimeoutMs)
-			for (const handle of trackedHandles) {
-				const syncInfo = handle.getSyncInfo(storageId as never)
-				const remoteHeads = syncInfo?.lastHeads
-				if (!remoteHeads || A.equals(remoteHeads, handle.heads())) {
-					continue
-				}
-
-				const {documentId} = parseAutomergeUrl(handle.url)
-				const remoteUrl = stringifyAutomergeUrl({documentId, heads: remoteHeads})
-				try {
-					await this.repo.find(remoteUrl)
-				} catch {
-					// Fall back to the current local handle state if remote materialization fails.
-				}
-			}
+			await waitForSync(trackedHandles, storageId)
+			await this.materializeTrackedRemoteHeads(trackedHandles, storageId)
 			return
 		}
 
@@ -1940,6 +1942,48 @@ export class SyncEngine {
 			stableChecksRequired: 3,
 			handles: trackedHandles,
 		})
+	}
+
+	private async materializeTrackedRemoteHeads(
+		handles: DocHandle<unknown>[],
+		storageId: string
+	): Promise<void> {
+		for (const handle of handles) {
+			const syncInfo = handle.getSyncInfo(storageId as never)
+			const remoteHeads = syncInfo?.lastHeads
+			if (!remoteHeads || A.equals(remoteHeads, handle.heads())) {
+				continue
+			}
+
+			const {documentId} = parseAutomergeUrl(handle.url)
+			const remoteUrl = stringifyAutomergeUrl({documentId, heads: remoteHeads})
+			try {
+				await this.repo.find(remoteUrl)
+			} catch {
+				// Leave detection to fall back to the current local handle state.
+			}
+		}
+	}
+
+	private async findReadyHandle(
+		url: AutomergeUrl,
+		options: {maxRetries?: number; retryDelayMs?: number} = {}
+	): Promise<DocHandle<unknown> | undefined> {
+		const {maxRetries = 5, retryDelayMs = 200} = options
+
+		for (let attempt = 0; attempt < maxRetries; attempt++) {
+			try {
+				const handle = await this.repo.find(url)
+				handle.doc()
+				return handle
+			} catch {
+				if (attempt < maxRetries - 1) {
+					await new Promise(r => setTimeout(r, retryDelayMs * (attempt + 1)))
+				}
+			}
+		}
+
+		return undefined
 	}
 
 }

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -453,54 +453,7 @@ export class SyncEngine {
 
 			debug(`sync: rootDirectoryUrl=${snapshot.rootDirectoryUrl}, files=${snapshot.files.size}, dirs=${snapshot.directories.size}`)
 
-			// Wait for initial sync to receive any pending remote changes
-			if (this.config.sync_enabled && snapshot.rootDirectoryUrl) {
-				debug("sync: waiting for root document to be ready")
-				out.update("Waiting for root document from server")
-
-				// Wait for the root document to be fetched from the network.
-				// repo.find() rejects with "unavailable" if the server doesn't
-				// have the document yet, so we retry with backoff.
-				// This is critical for clone scenarios.
-				const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
-				const maxAttempts = 6
-				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-					try {
-						const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
-						rootHandle.doc() // throws if not ready
-						debug(`sync: root document ready (attempt ${attempt})`)
-						break
-					} catch (error) {
-						const isUnavailable = String(error).includes("unavailable") || String(error).includes("not ready")
-						if (isUnavailable && attempt < maxAttempts) {
-							const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000)
-							debug(`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`)
-							out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
-							await new Promise(r => setTimeout(r, delay))
-						} else {
-							debug(`sync: root document unavailable after ${maxAttempts} attempts: ${error}`)
-							out.taskLine(`Root document unavailable: ${error}`, true)
-							break
-						}
-					}
-				}
-
-				debug("sync: waiting for initial bidirectional sync")
-				out.update("Waiting for initial sync from server")
-				try {
-					await waitForBidirectionalSync(
-						this.repo,
-						snapshot.rootDirectoryUrl,
-						{
-							timeoutMs: 5000, // Increased timeout for initial sync
-							pollIntervalMs: 100,
-							stableChecksRequired: 3,
-						}
-					)
-				} catch (error) {
-					out.taskLine(`Initial sync: ${error}`, true)
-				}
-			}
+			await this.refreshRemoteState(snapshot)
 
 			// Detect all changes
 			debug("sync: detecting changes")
@@ -1765,6 +1718,12 @@ export class SyncEngine {
 			}
 		}
 
+		try {
+			await this.refreshRemoteState(snapshot, {bestEffort: true})
+		} catch {
+			// Best-effort refresh: preview should still work from local state.
+		}
+
 		const changes = await this.changeDetector.detectChanges(snapshot)
 		const {moves} = await this.moveDetector.detectMoves(changes, snapshot)
 
@@ -1857,6 +1816,130 @@ export class SyncEngine {
 		} catch (error) {
 			// Failed to update root directory timestamp
 		}
+	}
+
+	private async refreshRemoteState(
+		snapshot: SyncSnapshot,
+		options: {bestEffort?: boolean} = {}
+	): Promise<void> {
+		if (!this.config.sync_enabled || !snapshot.rootDirectoryUrl) {
+			return
+		}
+
+		const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
+		const bestEffort = options.bestEffort ?? false
+		const maxAttempts = bestEffort ? 2 : 6
+
+		debug("sync: waiting for root document to be ready")
+		out.update("Waiting for root document from server")
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
+				rootHandle.doc()
+				debug(`sync: root document ready (attempt ${attempt})`)
+				break
+			} catch (error) {
+				const isUnavailable =
+					String(error).includes("unavailable") ||
+					String(error).includes("not ready")
+				if (isUnavailable && attempt < maxAttempts) {
+					const delay = bestEffort
+						? Math.min(250 * Math.pow(2, attempt - 1), 500)
+						: Math.min(1000 * Math.pow(2, attempt - 1), 10000)
+					debug(
+						`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`
+					)
+					out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
+					await new Promise(r => setTimeout(r, delay))
+				} else {
+					if (bestEffort && isUnavailable) {
+						debug(
+							`sync: root document unavailable after ${attempt} attempts in best-effort mode`
+						)
+						return
+					}
+					debug(
+						`sync: root document unavailable after ${maxAttempts} attempts: ${error}`
+					)
+					out.taskLine(`Root document unavailable: ${error}`, true)
+					break
+				}
+			}
+		}
+
+		debug("sync: waiting for initial bidirectional sync")
+		out.update("Waiting for initial sync from server")
+		try {
+			await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+				timeoutMs: 5000,
+				pollIntervalMs: 100,
+				stableChecksRequired: 3,
+			})
+		} catch (error) {
+			out.taskLine(`Initial sync: ${error}`, true)
+		}
+
+		const trackedHandles: DocHandle<unknown>[] = []
+		const trackedUrls = new Set<AutomergeUrl>()
+		trackedUrls.add(plainRootUrl)
+		for (const entry of snapshot.directories.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+		for (const entry of snapshot.files.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+
+		for (const url of trackedUrls) {
+			try {
+				const handle = await this.repo.find(url)
+				handle.doc()
+				trackedHandles.push(handle)
+			} catch {
+				// Change detection will retry unavailable documents.
+			}
+		}
+
+		if (trackedHandles.length === 0) {
+			return
+		}
+
+		debug(
+			`sync: refreshing ${trackedHandles.length} tracked documents before change detection`
+		)
+		out.update(`Refreshing ${trackedHandles.length} tracked documents`)
+
+		const storageId = this.config.subduction
+			? undefined
+			: this.config.sync_server_storage_id
+		const syncTimeoutMs = Number(process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? 60000)
+
+		if (storageId) {
+			await waitForSync(trackedHandles, storageId, syncTimeoutMs)
+			for (const handle of trackedHandles) {
+				const syncInfo = handle.getSyncInfo(storageId as never)
+				const remoteHeads = syncInfo?.lastHeads
+				if (!remoteHeads || A.equals(remoteHeads, handle.heads())) {
+					continue
+				}
+
+				const {documentId} = parseAutomergeUrl(handle.url)
+				const remoteUrl = stringifyAutomergeUrl({documentId, heads: remoteHeads})
+				try {
+					await this.repo.find(remoteUrl)
+				} catch {
+					// Fall back to the current local handle state if remote materialization fails.
+				}
+			}
+			return
+		}
+
+		await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+			timeoutMs: BIDIRECTIONAL_SYNC_TIMEOUT_MS,
+			pollIntervalMs: 100,
+			stableChecksRequired: 3,
+			handles: trackedHandles,
+		})
 	}
 
 }

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -86,6 +86,4 @@ export interface DetectedChange {
 	remoteContent: string | Uint8Array | null
 	localHead?: UrlHeads
 	remoteHead?: UrlHeads
-	/** New remote URL when the remote document was replaced (artifact URL change) */
-	remoteUrl?: AutomergeUrl
 }

--- a/src/utils/text-diff.ts
+++ b/src/utils/text-diff.ts
@@ -99,3 +99,78 @@ export function spliceText(
 		}
 	}
 }
+
+interface TextEditSpan {
+	start: number
+	end: number
+	text: string
+}
+
+export function mergeTextWithBase(
+	baseContent: string,
+	localContent: string,
+	remoteContent: string
+): string {
+	if (localContent === remoteContent) return localContent
+	if (localContent === baseContent) return remoteContent
+	if (remoteContent === baseContent) return localContent
+
+	const localEdit = getTextEditSpan(baseContent, localContent)
+	const remoteEdit = getTextEditSpan(baseContent, remoteContent)
+
+	if (
+		localEdit.end <= remoteEdit.start ||
+		remoteEdit.end <= localEdit.start
+	) {
+		return applyEdits(baseContent, [localEdit, remoteEdit])
+	}
+
+	if (
+		localEdit.start === localEdit.end &&
+		remoteEdit.start === remoteEdit.end &&
+		localEdit.start === remoteEdit.start
+	) {
+		return applyEdits(baseContent, [remoteEdit, localEdit])
+	}
+
+	return remoteContent
+}
+
+function getTextEditSpan(baseContent: string, nextContent: string): TextEditSpan {
+	let start = 0
+	while (
+		start < baseContent.length &&
+		start < nextContent.length &&
+		baseContent[start] === nextContent[start]
+	) {
+		start++
+	}
+
+	let baseEnd = baseContent.length
+	let nextEnd = nextContent.length
+	while (
+		baseEnd > start &&
+		nextEnd > start &&
+		baseContent[baseEnd - 1] === nextContent[nextEnd - 1]
+	) {
+		baseEnd--
+		nextEnd--
+	}
+
+	return {
+		start,
+		end: baseEnd,
+		text: nextContent.slice(start, nextEnd),
+	}
+}
+
+function applyEdits(baseContent: string, edits: TextEditSpan[]): string {
+	let merged = baseContent
+	for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+		merged =
+			merged.slice(0, edit.start) +
+			edit.text +
+			merged.slice(edit.end)
+	}
+	return merged
+}

--- a/test/integration/concurrent-same-file-sync.test.ts
+++ b/test/integration/concurrent-same-file-sync.test.ts
@@ -1,0 +1,109 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as tmp from "tmp";
+
+const execFilePromise = promisify(execFile);
+const PUSHWORK_CLI = path.join(__dirname, "../../dist/cli.js");
+
+async function pushwork(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFilePromise("node", [PUSHWORK_CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        PUSHWORK_SYNC_TIMEOUT_MS: process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? "5000",
+        PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS:
+          process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? "2000",
+        PUSHWORK_SYNC_GRACE_MS: process.env.PUSHWORK_SYNC_GRACE_MS ?? "0",
+      },
+    });
+  } catch (error: any) {
+    throw new Error(
+      `pushwork ${args.join(" ")} failed: ${error.message}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+    );
+  }
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+describe("Concurrent same-file sync", () => {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = tmpObj.name;
+    cleanup = tmpObj.removeCallback;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("preserves both peers' concurrent edits to the same text file", async () => {
+    const repoA = path.join(tmpDir, "repo-a");
+    const repoB = path.join(tmpDir, "repo-b");
+    await fs.mkdir(repoA);
+    await fs.mkdir(repoB);
+
+    const baseline = [
+      "# Inbox",
+      "",
+      "Quick captures, unprocessed.",
+      "",
+      "- [ ] Try the Pushwork interop loop end to end",
+    ].join("\n");
+
+    await fs.writeFile(path.join(repoA, "inbox.md"), `${baseline}\n`);
+    await pushwork(["init", "."], repoA);
+
+    const { stdout: rootUrl } = await pushwork(["url"], repoA);
+    await pushwork(["clone", rootUrl.trim(), repoB], tmpDir);
+
+    const primaryMarker = "PRIMARY-CONCURRENT";
+    const cloneMarker = "CLONE-CONCURRENT";
+
+    await fs.writeFile(
+      path.join(repoA, "inbox.md"),
+      `${baseline}\n${primaryMarker}\n`,
+    );
+    await fs.writeFile(
+      path.join(repoB, "inbox.md"),
+      `${baseline}\n${cloneMarker}\n`,
+    );
+
+    await pushwork(["sync", "--gentle"], repoA);
+    await pushwork(["sync", "--gentle"], repoB);
+
+    const repoObserver = path.join(tmpDir, "repo-observer");
+    await fs.mkdir(repoObserver);
+    await pushwork(["clone", rootUrl.trim(), repoObserver], tmpDir);
+
+    const observerAfterCloneSync = await readFile(path.join(repoObserver, "inbox.md"));
+    expect(observerAfterCloneSync).toContain(primaryMarker);
+    expect(observerAfterCloneSync).toContain(cloneMarker);
+
+    await pushwork(["sync", "--gentle"], repoA);
+    const afterResyncA = await readFile(path.join(repoA, "inbox.md"));
+    expect(afterResyncA).toContain(primaryMarker);
+    expect(afterResyncA).toContain(cloneMarker);
+
+    await pushwork(["sync", "--gentle"], repoB);
+
+    const finalA = await readFile(path.join(repoA, "inbox.md"));
+    const finalB = await readFile(path.join(repoB, "inbox.md"));
+
+    expect(finalA).toContain(primaryMarker);
+    expect(finalA).toContain(cloneMarker);
+    expect(finalB).toContain(primaryMarker);
+    expect(finalB).toContain(cloneMarker);
+  }, 60_000);
+});

--- a/test/integration/existing-workspace-diff.test.ts
+++ b/test/integration/existing-workspace-diff.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as tmp from "tmp";
+
+const execFilePromise = promisify(execFile);
+const PUSHWORK_CLI = path.join(__dirname, "../../dist/cli.js");
+
+async function pushwork(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFilePromise("node", [PUSHWORK_CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        PUSHWORK_SYNC_TIMEOUT_MS: process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? "5000",
+        PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS:
+          process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? "2000",
+        PUSHWORK_SYNC_GRACE_MS: process.env.PUSHWORK_SYNC_GRACE_MS ?? "0",
+      },
+    });
+  } catch (error: any) {
+    throw new Error(
+      `pushwork ${args.join(" ")} failed: ${error.message}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+    );
+  }
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+describe("Existing-workspace diff", () => {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = tmpObj.name;
+    cleanup = tmpObj.removeCallback;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows remote-only tracked file changes in an existing clone", async () => {
+    const repoA = path.join(tmpDir, "repo-a");
+    const repoB = path.join(tmpDir, "repo-b");
+    const repoObserver = path.join(tmpDir, "repo-observer");
+    await fs.mkdir(repoA);
+    await fs.mkdir(repoB);
+    await fs.mkdir(repoObserver);
+
+    await fs.writeFile(path.join(repoA, "hello.md"), "hello\n");
+    await pushwork(["init", "."], repoA);
+
+    const { stdout: rootUrl } = await pushwork(["url"], repoA);
+    await pushwork(["clone", rootUrl.trim(), repoB], tmpDir);
+
+    await fs.mkdir(path.join(repoA, "alpha"));
+    await fs.writeFile(path.join(repoA, "alpha", "second.md"), "second file\n");
+    await pushwork(["sync", "--gentle"], repoA);
+
+    await pushwork(["clone", rootUrl.trim(), repoObserver], tmpDir);
+    expect(await readFile(path.join(repoObserver, "alpha", "second.md"))).toBe(
+      "second file\n",
+    );
+
+    const diffOutput = (await pushwork(["diff"], repoB)).stdout;
+    expect(diffOutput).not.toContain("No changes detected");
+    expect(diffOutput).toContain("[remote] alpha/second.md");
+    expect(diffOutput).toContain("alpha/second.md");
+  }, 60_000);
+
+  it("still shows local diffs when the sync server is unreachable", async () => {
+    const repo = path.join(tmpDir, "repo-offline");
+    await fs.mkdir(repo);
+
+    const previousSyncTimeout = process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+    const previousBidirectionalTimeout = process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+    process.env.PUSHWORK_SYNC_TIMEOUT_MS = "1000";
+    process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = "500";
+
+    try {
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\n");
+      await pushwork(["init", "."], repo);
+
+      const configPath = path.join(repo, ".pushwork", "config.json");
+      const config = JSON.parse(await readFile(configPath));
+      config.sync_server = "ws://127.0.0.1:1";
+      config.sync_server_storage_id = "00000000-0000-0000-0000-000000000000";
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\nlocal change\n");
+
+      const diffOutput = (await pushwork(["diff"], repo)).stdout;
+      expect(diffOutput).not.toContain("No changes detected");
+      expect(diffOutput).toContain("[local]  hello.md");
+      expect(diffOutput).toContain("local change");
+    } finally {
+      if (previousSyncTimeout === undefined) {
+        delete process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_SYNC_TIMEOUT_MS = previousSyncTimeout;
+      }
+
+      if (previousBidirectionalTimeout === undefined) {
+        delete process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = previousBidirectionalTimeout;
+      }
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary
- add a focused regression test for concurrent same-file edits in two existing workspaces
- merge local and remote text changes against the snapshot base so both peers' edits survive the next sync round

## Test intent
The regression mirrors the canonical "two writers, same file" collaboration pattern: peers A and B both clone the same workspace, each appends a different line to the same tracked text file, and each runs `pushwork sync` once without coordinating. 

## Stack note
This branch is stacked on top of #29. The two commits at the base of this PR's diff (`2d1d17e`, `de93822`) are #29's commits, included here so the regression resolves against a tree that has the stale-diff fix. After #29 lands I will rebase this branch onto main; the only commits authored by this PR are `75c967c` (test) and `597fb66` (fix).

## Testing
- pnpm run build
- pnpm exec jest test/integration/concurrent-same-file-sync.test.ts --runInBand