### PR TITLE
Fix remote-only updates from non-Pushwork authors

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -436,8 +436,8 @@ export async function diff(
 ): Promise<void> {
   out.task("Analyzing changes");
 
-  const { repo, syncEngine } = await setupCommandContext(targetPath, { syncEnabled: false });
-  const preview = await syncEngine.previewChanges();
+	const { repo, syncEngine } = await setupCommandContext(targetPath);
+	const preview = await syncEngine.previewChanges();
 
   out.done();
 
@@ -445,6 +445,7 @@ export async function diff(
     for (const change of preview.changes) {
       out.log(change.path);
     }
+    await safeRepoShutdown(repo);
     return;
   }
 

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -453,54 +453,7 @@ export class SyncEngine {
 
 			debug(`sync: rootDirectoryUrl=${snapshot.rootDirectoryUrl}, files=${snapshot.files.size}, dirs=${snapshot.directories.size}`)
 
-			// Wait for initial sync to receive any pending remote changes
-			if (this.config.sync_enabled && snapshot.rootDirectoryUrl) {
-				debug("sync: waiting for root document to be ready")
-				out.update("Waiting for root document from server")
-
-				// Wait for the root document to be fetched from the network.
-				// repo.find() rejects with "unavailable" if the server doesn't
-				// have the document yet, so we retry with backoff.
-				// This is critical for clone scenarios.
-				const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
-				const maxAttempts = 6
-				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-					try {
-						const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
-						rootHandle.doc() // throws if not ready
-						debug(`sync: root document ready (attempt ${attempt})`)
-						break
-					} catch (error) {
-						const isUnavailable = String(error).includes("unavailable") || String(error).includes("not ready")
-						if (isUnavailable && attempt < maxAttempts) {
-							const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000)
-							debug(`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`)
-							out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
-							await new Promise(r => setTimeout(r, delay))
-						} else {
-							debug(`sync: root document unavailable after ${maxAttempts} attempts: ${error}`)
-							out.taskLine(`Root document unavailable: ${error}`, true)
-							break
-						}
-					}
-				}
-
-				debug("sync: waiting for initial bidirectional sync")
-				out.update("Waiting for initial sync from server")
-				try {
-					await waitForBidirectionalSync(
-						this.repo,
-						snapshot.rootDirectoryUrl,
-						{
-							timeoutMs: 5000, // Increased timeout for initial sync
-							pollIntervalMs: 100,
-							stableChecksRequired: 3,
-						}
-					)
-				} catch (error) {
-					out.taskLine(`Initial sync: ${error}`, true)
-				}
-			}
+			await this.refreshRemoteState(snapshot)
 
 			// Detect all changes
 			debug("sync: detecting changes")
@@ -1765,6 +1718,12 @@ export class SyncEngine {
 			}
 		}
 
+		try {
+			await this.refreshRemoteState(snapshot, {bestEffort: true})
+		} catch {
+			// Best-effort refresh: preview should still work from local state.
+		}
+
 		const changes = await this.changeDetector.detectChanges(snapshot)
 		const {moves} = await this.moveDetector.detectMoves(changes, snapshot)
 
@@ -1857,6 +1816,130 @@ export class SyncEngine {
 		} catch (error) {
 			// Failed to update root directory timestamp
 		}
+	}
+
+	private async refreshRemoteState(
+		snapshot: SyncSnapshot,
+		options: {bestEffort?: boolean} = {}
+	): Promise<void> {
+		if (!this.config.sync_enabled || !snapshot.rootDirectoryUrl) {
+			return
+		}
+
+		const plainRootUrl = getPlainUrl(snapshot.rootDirectoryUrl)
+		const bestEffort = options.bestEffort ?? false
+		const maxAttempts = bestEffort ? 2 : 6
+
+		debug("sync: waiting for root document to be ready")
+		out.update("Waiting for root document from server")
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				const rootHandle = await this.repo.find<DirectoryDocument>(plainRootUrl)
+				rootHandle.doc()
+				debug(`sync: root document ready (attempt ${attempt})`)
+				break
+			} catch (error) {
+				const isUnavailable =
+					String(error).includes("unavailable") ||
+					String(error).includes("not ready")
+				if (isUnavailable && attempt < maxAttempts) {
+					const delay = bestEffort
+						? Math.min(250 * Math.pow(2, attempt - 1), 500)
+						: Math.min(1000 * Math.pow(2, attempt - 1), 10000)
+					debug(
+						`sync: root document not available (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`
+					)
+					out.update(`Waiting for root document (attempt ${attempt}/${maxAttempts})`)
+					await new Promise(r => setTimeout(r, delay))
+				} else {
+					if (bestEffort && isUnavailable) {
+						debug(
+							`sync: root document unavailable after ${attempt} attempts in best-effort mode`
+						)
+						return
+					}
+					debug(
+						`sync: root document unavailable after ${maxAttempts} attempts: ${error}`
+					)
+					out.taskLine(`Root document unavailable: ${error}`, true)
+					break
+				}
+			}
+		}
+
+		debug("sync: waiting for initial bidirectional sync")
+		out.update("Waiting for initial sync from server")
+		try {
+			await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+				timeoutMs: 5000,
+				pollIntervalMs: 100,
+				stableChecksRequired: 3,
+			})
+		} catch (error) {
+			out.taskLine(`Initial sync: ${error}`, true)
+		}
+
+		const trackedHandles: DocHandle<unknown>[] = []
+		const trackedUrls = new Set<AutomergeUrl>()
+		trackedUrls.add(plainRootUrl)
+		for (const entry of snapshot.directories.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+		for (const entry of snapshot.files.values()) {
+			trackedUrls.add(getPlainUrl(entry.url))
+		}
+
+		for (const url of trackedUrls) {
+			try {
+				const handle = await this.repo.find(url)
+				handle.doc()
+				trackedHandles.push(handle)
+			} catch {
+				// Change detection will retry unavailable documents.
+			}
+		}
+
+		if (trackedHandles.length === 0) {
+			return
+		}
+
+		debug(
+			`sync: refreshing ${trackedHandles.length} tracked documents before change detection`
+		)
+		out.update(`Refreshing ${trackedHandles.length} tracked documents`)
+
+		const storageId = this.config.subduction
+			? undefined
+			: this.config.sync_server_storage_id
+		const syncTimeoutMs = Number(process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? 60000)
+
+		if (storageId) {
+			await waitForSync(trackedHandles, storageId, syncTimeoutMs)
+			for (const handle of trackedHandles) {
+				const syncInfo = handle.getSyncInfo(storageId as never)
+				const remoteHeads = syncInfo?.lastHeads
+				if (!remoteHeads || A.equals(remoteHeads, handle.heads())) {
+					continue
+				}
+
+				const {documentId} = parseAutomergeUrl(handle.url)
+				const remoteUrl = stringifyAutomergeUrl({documentId, heads: remoteHeads})
+				try {
+					await this.repo.find(remoteUrl)
+				} catch {
+					// Fall back to the current local handle state if remote materialization fails.
+				}
+			}
+			return
+		}
+
+		await waitForBidirectionalSync(this.repo, snapshot.rootDirectoryUrl, {
+			timeoutMs: BIDIRECTIONAL_SYNC_TIMEOUT_MS,
+			pollIntervalMs: 100,
+			stableChecksRequired: 3,
+			handles: trackedHandles,
+		})
 	}
 
 }

--- a/src/core/sync-engine.ts
+++ b/src/core/sync-engine.ts
@@ -492,6 +492,7 @@ export class SyncEngine {
 				// falls back to head-stability polling. In WebSocket mode,
 				// pass the StorageId for precise getSyncInfo-based verification.
 				const storageId = sub ? undefined : this.config.sync_server_storage_id
+				const syncTimeoutMs = Number(process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? 60000)
 
 				try {
 					// Ensure root directory handle is tracked for sync
@@ -513,7 +514,8 @@ export class SyncEngine {
 						out.update(`Uploading ${allHandles.length} documents to sync server`)
 						const {failed} = await waitForSync(
 							allHandles,
-							storageId
+							storageId,
+							syncTimeoutMs
 						)
 
 						// Recreate failed documents and retry once.
@@ -528,7 +530,8 @@ export class SyncEngine {
 								out.update(`Retrying ${retryHandles.length} recreated documents`)
 								const retry = await waitForSync(
 									retryHandles,
-									storageId
+									storageId,
+									syncTimeoutMs
 								)
 								if (retry.failed.length > 0) {
 									const msg = `${retry.failed.length} documents failed to sync to server after recreation`
@@ -583,7 +586,8 @@ export class SyncEngine {
 						out.update("Syncing root directory update")
 						const rootSync = await waitForSync(
 							[rootHandle],
-							storageId
+							storageId,
+							syncTimeoutMs
 						)
 						if (rootSync.failed.length > 0) {
 							const msg = "Root directory update did not converge to server; consumers may not see recent changes until next sync"

--- a/test/integration/existing-workspace-diff.test.ts
+++ b/test/integration/existing-workspace-diff.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import * as tmp from "tmp";
+
+const execFilePromise = promisify(execFile);
+const PUSHWORK_CLI = path.join(__dirname, "../../dist/cli.js");
+
+async function pushwork(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFilePromise("node", [PUSHWORK_CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        PUSHWORK_SYNC_TIMEOUT_MS: process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? "5000",
+        PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS:
+          process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? "2000",
+        PUSHWORK_SYNC_GRACE_MS: process.env.PUSHWORK_SYNC_GRACE_MS ?? "0",
+      },
+    });
+  } catch (error: any) {
+    throw new Error(
+      `pushwork ${args.join(" ")} failed: ${error.message}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+    );
+  }
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+describe("Existing-workspace diff", () => {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = tmpObj.name;
+    cleanup = tmpObj.removeCallback;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows remote-only tracked file changes in an existing clone", async () => {
+    const repoA = path.join(tmpDir, "repo-a");
+    const repoB = path.join(tmpDir, "repo-b");
+    const repoObserver = path.join(tmpDir, "repo-observer");
+    await fs.mkdir(repoA);
+    await fs.mkdir(repoB);
+    await fs.mkdir(repoObserver);
+
+    await fs.writeFile(path.join(repoA, "hello.md"), "hello\n");
+    await pushwork(["init", "."], repoA);
+
+    const { stdout: rootUrl } = await pushwork(["url"], repoA);
+    await pushwork(["clone", rootUrl.trim(), repoB], tmpDir);
+
+    await fs.mkdir(path.join(repoA, "alpha"));
+    await fs.writeFile(path.join(repoA, "alpha", "second.md"), "second file\n");
+    await pushwork(["sync", "--gentle"], repoA);
+
+    await pushwork(["clone", rootUrl.trim(), repoObserver], tmpDir);
+    expect(await readFile(path.join(repoObserver, "alpha", "second.md"))).toBe(
+      "second file\n",
+    );
+
+    const diffOutput = (await pushwork(["diff"], repoB)).stdout;
+    expect(diffOutput).not.toContain("No changes detected");
+    expect(diffOutput).toContain("[remote] alpha/second.md");
+    expect(diffOutput).toContain("alpha/second.md");
+  }, 60_000);
+
+  it("still shows local diffs when the sync server is unreachable", async () => {
+    const repo = path.join(tmpDir, "repo-offline");
+    await fs.mkdir(repo);
+
+    const previousSyncTimeout = process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+    const previousBidirectionalTimeout = process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+    process.env.PUSHWORK_SYNC_TIMEOUT_MS = "1000";
+    process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = "500";
+
+    try {
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\n");
+      await pushwork(["init", "."], repo);
+
+      const configPath = path.join(repo, ".pushwork", "config.json");
+      const config = JSON.parse(await readFile(configPath));
+      config.sync_server = "ws://127.0.0.1:1";
+      config.sync_server_storage_id = "00000000-0000-0000-0000-000000000000";
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+      await fs.writeFile(path.join(repo, "hello.md"), "hello\nlocal change\n");
+
+      const diffOutput = (await pushwork(["diff"], repo)).stdout;
+      expect(diffOutput).not.toContain("No changes detected");
+      expect(diffOutput).toContain("[local]  hello.md");
+      expect(diffOutput).toContain("local change");
+    } finally {
+      if (previousSyncTimeout === undefined) {
+        delete process.env.PUSHWORK_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_SYNC_TIMEOUT_MS = previousSyncTimeout;
+      }
+
+      if (previousBidirectionalTimeout === undefined) {
+        delete process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS;
+      } else {
+        process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS = previousBidirectionalTimeout;
+      }
+    }
+  }, 60_000);
+});

--- a/test/integration/non-pushwork-author-sync.test.ts
+++ b/test/integration/non-pushwork-author-sync.test.ts
@@ -1,0 +1,183 @@
+// Set SYNC_SERVER_BIN to the path of an `automerge-repo-sync-server` binary
+// to run this suite. Without it the suite is skipped, since the regression
+// requires a non-Pushwork author writing to a local sync server.
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as net from "net";
+import { spawn, execFile } from "child_process";
+import { promisify } from "util";
+import * as tmp from "tmp";
+
+const execFilePromise = promisify(execFile);
+const PUSHWORK_CLI = path.join(__dirname, "../../dist/cli.js");
+const MANUAL_WRITER = path.join(__dirname, "support/manual-patchwork-writer.mjs");
+const SYNC_SERVER_BIN = process.env.SYNC_SERVER_BIN;
+
+async function pushwork(
+  args: string[],
+  cwd: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFilePromise("node", [PUSHWORK_CLI, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        PUSHWORK_SYNC_TIMEOUT_MS: process.env.PUSHWORK_SYNC_TIMEOUT_MS ?? "5000",
+        PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS:
+          process.env.PUSHWORK_BIDIRECTIONAL_SYNC_TIMEOUT_MS ?? "2000",
+        PUSHWORK_SYNC_GRACE_MS: process.env.PUSHWORK_SYNC_GRACE_MS ?? "0",
+      },
+    });
+  } catch (error: any) {
+    throw new Error(
+      `pushwork ${args.join(" ")} failed: ${error.message}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+    );
+  }
+}
+
+async function runWriter(
+  action: "init" | "add-second",
+  writerDir: string,
+  serverUrl: string,
+  storageId: string,
+): Promise<string> {
+  const { stdout } = await execFilePromise("node", [MANUAL_WRITER, action, writerDir, serverUrl, storageId], {
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+  return stdout.trim();
+}
+
+async function readFile(filePath: string): Promise<string> {
+  return fs.readFile(filePath, "utf8");
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to allocate port"));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+    server.on("error", reject);
+  });
+}
+
+async function startSyncServer(stateDir: string): Promise<{
+  process: ReturnType<typeof spawn>;
+  url: string;
+  storageId: string;
+}> {
+  if (!SYNC_SERVER_BIN) {
+    throw new Error("SYNC_SERVER_BIN is not set");
+  }
+  const port = await getFreePort();
+  const url = `ws://localhost:${port}`;
+  await fs.mkdir(path.join(stateDir, "data"), { recursive: true });
+
+  const child = spawn(SYNC_SERVER_BIN, [], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      DATA_DIR: path.join(stateDir, "data"),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const storageId = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("sync server did not print Storage ID"));
+    }, 10_000);
+
+    const onChunk = (chunk: Buffer) => {
+      const match = String(chunk).match(/Storage ID:\s*([0-9a-f-]+)/i);
+      if (!match) return;
+      clearTimeout(timeout);
+      child.stdout.off("data", onChunk);
+      child.stderr.off("data", onChunk);
+      resolve(match[1]);
+    };
+
+    child.stdout.on("data", onChunk);
+    child.stderr.on("data", onChunk);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`sync server exited early (code=${code}, signal=${signal})`));
+    });
+  });
+
+  return { process: child, url, storageId };
+}
+
+async function stopSyncServer(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.killed) return;
+  child.kill("SIGTERM");
+  await new Promise(resolve => child.once("exit", resolve));
+}
+
+const describeWithSyncServer = SYNC_SERVER_BIN ? describe : describe.skip;
+
+describeWithSyncServer("Non-Pushwork author compatibility", () => {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = tmpObj.name;
+    cleanup = tmpObj.removeCallback;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("pulls a remote-only incremental new file from a non-Pushwork author into an existing clone", async () => {
+    const writerDir = path.join(tmpDir, "writer-repo");
+    const repoClone = path.join(tmpDir, "repo-clone");
+    const repoObserver = path.join(tmpDir, "repo-observer");
+    await fs.mkdir(repoClone);
+    await fs.mkdir(repoObserver);
+
+    const server = await startSyncServer(path.join(tmpDir, "sync-server"));
+    try {
+      const rootUrl = await runWriter("init", writerDir, server.url, server.storageId);
+
+      await pushwork(
+        ["clone", "--force", "--sync-server", server.url, server.storageId, "--", rootUrl, repoClone],
+        tmpDir,
+      );
+
+      await runWriter("add-second", writerDir, server.url, server.storageId);
+
+      await pushwork(
+        ["clone", "--force", "--sync-server", server.url, server.storageId, "--", rootUrl, repoObserver],
+        tmpDir,
+      );
+
+      expect(await readFile(path.join(repoObserver, "alpha", "second.md"))).toBe("second file\n");
+
+      const diffOutput = (await pushwork(["diff", "--name-only"], repoClone)).stdout;
+      expect(diffOutput).toContain("alpha/second.md");
+
+      await pushwork(["sync", "--gentle"], repoClone);
+      expect(await pathExists(path.join(repoClone, "alpha", "second.md"))).toBe(true);
+      expect(await readFile(path.join(repoClone, "alpha", "second.md"))).toBe("second file\n");
+    } finally {
+      await stopSyncServer(server.process).catch(() => undefined);
+    }
+  }, 60_000);
+});

--- a/test/integration/support/manual-patchwork-writer.mjs
+++ b/test/integration/support/manual-patchwork-writer.mjs
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Repo, initSubduction } from "@automerge/automerge-repo";
+import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+
+const [action, writerDir, serverUrl, storageId] = process.argv.slice(2);
+
+if (!action || !writerDir || !serverUrl || !storageId) {
+  throw new Error("usage: manual-patchwork-writer.mjs <action> <writerDir> <serverUrl> <storageId>");
+}
+
+const statePath = path.join(writerDir, "writer-state.json");
+
+function createRepo() {
+  return new Repo({
+    storage: new NodeFSStorageAdapter(path.join(writerDir, "automerge")),
+    network: [new BrowserWebSocketClientAdapter(serverUrl)],
+  });
+}
+
+await initSubduction();
+
+async function pauseForRelay() {
+  await new Promise(resolve => setTimeout(resolve, 2000));
+}
+
+async function initWriter() {
+  await fs.mkdir(writerDir, { recursive: true });
+  const repo = createRepo();
+  try {
+    const rootHandle = repo.create({
+      "@patchwork": { type: "folder" },
+      name: "root",
+      title: "root",
+      docs: [],
+    });
+    const alphaHandle = repo.create({
+      "@patchwork": { type: "folder" },
+      name: "alpha",
+      title: "alpha",
+      docs: [],
+    });
+    const helloHandle = repo.create({
+      "@patchwork": { type: "file" },
+      name: "hello.md",
+      extension: "md",
+      mimeType: "text/markdown",
+      contentType: "public.markdown",
+      content: "# hello\n",
+      metadata: { permissions: 0o644 },
+    });
+
+    alphaHandle.change(doc => {
+      doc.docs.push({ name: "hello.md", type: "file", url: helloHandle.url });
+    });
+    rootHandle.change(doc => {
+      doc.docs.push({ name: "alpha", type: "folder", url: alphaHandle.url });
+    });
+
+    await pauseForRelay();
+
+    await fs.writeFile(
+      statePath,
+      JSON.stringify({ rootUrl: rootHandle.url, alphaUrl: alphaHandle.url }, null, 2),
+      "utf8",
+    );
+
+    process.stdout.write(rootHandle.url);
+  } finally {
+    await repo.shutdown();
+  }
+}
+
+async function addSecondFile() {
+  const state = JSON.parse(await fs.readFile(statePath, "utf8"));
+  const repo = createRepo();
+  try {
+    const alphaHandle = await repo.find(state.alphaUrl);
+    const secondHandle = repo.create({
+      "@patchwork": { type: "file" },
+      name: "second.md",
+      extension: "md",
+      mimeType: "text/markdown",
+      contentType: "public.markdown",
+      content: "second file\n",
+      metadata: { permissions: 0o644 },
+    });
+
+    alphaHandle.change(doc => {
+      doc.docs.push({ name: "second.md", type: "file", url: secondHandle.url });
+    });
+
+    await pauseForRelay();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
+if (action === "init") {
+  await initWriter();
+} else if (action === "add-second") {
+  await addSecondFile();
+} else {
+  throw new Error(`unknown action: ${action}`);
+}


### PR DESCRIPTION
## Summary
- add a focused regression for remote-only incremental updates authored outside Pushwork
- thread `PUSHWORK_SYNC_TIMEOUT_MS` through the engine push-path `waitForSync` calls so the regression can fail fast on stuck convergence instead of hanging

## Test intent
The regression simulates a non-Pushwork collaborator — any other automerge-repo client talking the same sync protocol — writing a new tracked file into the workspace. A Pushwork clone that already exists from before the write should be able to observe and pull that file. In practice today `pushwork diff` and `pushwork sync` can hang on a doc whose convergence we cannot prove, because every CLI invocation comes in as a fresh peer and the sync protocol never reports back "synced." The test pins down the user-visible expectation (an existing clone sees and pulls the new file) and the env-driven timeout keeps the failure mode bounded.

## Stack note
This branch is stacked on top of #29. The two commits at the base of this PR's diff (`2d1d17e`, `de93822`) are #29's commits, included here so the regression resolves against a tree that has the stale-diff fix. After #29 lands I will rebase this branch onto main; the only commits authored by this PR are `f0a2480` (test) and `d37205f` (fix).

## Testing
- pnpm run build
- SYNC_SERVER_BIN=/path/to/automerge-repo-sync-server pnpm exec jest test/integration/non-pushwork-author-sync.test.ts --runInBand
- without `SYNC_SERVER_BIN` the test suite cleanly skips

## Notes
- A follow-up PR will introduce a way to ship `automerge-repo-sync-server` so CI can set `SYNC_SERVER_BIN` automatically.