### PR TITLE
Port benches from `reliability` branch to v2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pnpm-debug.log*
 
 # Build outputs
 dist/
+dist-bench/
 build/
 *.tsbuildinfo
 

--- a/bench/profile.ts
+++ b/bench/profile.ts
@@ -1,0 +1,240 @@
+/**
+ * Lightweight profiling + event-loop drift instrumentation for the bench.
+ *
+ * The most useful signal is *event-loop drift*: a monotonic timer that
+ * should fire every `intervalMs` but fires late when the thread is blocked
+ * in synchronous work. Drift discriminates "CPU-blocked" from
+ * "idle-waiting on the network" — the former is what starves Automerge's
+ * Wasm of the thread, missing sync-server pongs and stalling responses.
+ *
+ * Everything here is a no-op unless profiling is enabled, so the optional
+ * span wrappers add a single boolean check when off.
+ *
+ * Output goes to stderr so it never contaminates a command's stdout; a
+ * single machine-readable `PROFILE_JSON { ... }` line is emitted for the
+ * bench harness to parse.
+ */
+
+let enabled = !!process.env.PUSHWORK_PROFILE;
+
+export function setProfilingEnabled(on: boolean): void {
+	enabled = on;
+}
+
+export function isProfilingEnabled(): boolean {
+	return enabled;
+}
+
+interface PhaseStat {
+	totalMs: number;
+	count: number;
+	maxMs: number;
+}
+
+interface DriftState {
+	intervalMs: number;
+	thresholdMs: number;
+	last: number;
+	start: number;
+	samples: number;
+	events: number;
+	maxDriftMs: number;
+	maxDriftSpan: string;
+	totalBlockedMs: number;
+}
+
+const phases = new Map<string, PhaseStat>();
+const counters = new Map<string, number>();
+
+// Stack of currently-open profile spans, so the drift probe can attribute
+// the longest block to whatever phase was running when it happened.
+const activeSpans: string[] = [];
+let peakRssBytes = 0;
+let driftTimer: ReturnType<typeof setInterval> | null = null;
+let drift: DriftState | null = null;
+
+function record(name: string, ms: number): void {
+	const p = phases.get(name) ?? { totalMs: 0, count: 0, maxMs: 0 };
+	p.totalMs += ms;
+	p.count += 1;
+	if (ms > p.maxMs) p.maxMs = ms;
+	phases.set(name, p);
+}
+
+/** Time a synchronous span. No-op (just calls `fn`) when disabled. */
+export function profileSync<T>(name: string, fn: () => T): T {
+	if (!enabled) return fn();
+	const start = performance.now();
+	activeSpans.push(name);
+	try {
+		return fn();
+	} finally {
+		activeSpans.pop();
+		record(name, performance.now() - start);
+	}
+}
+
+/** Time an async span. No-op (just calls `fn`) when disabled. */
+export async function profileAsync<T>(
+	name: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	if (!enabled) return fn();
+	const start = performance.now();
+	activeSpans.push(name);
+	try {
+		return await fn();
+	} finally {
+		activeSpans.pop();
+		record(name, performance.now() - start);
+	}
+}
+
+/** Accumulate a named counter (e.g. docs created, chars diffed). */
+export function count(name: string, n = 1): void {
+	if (!enabled) return;
+	counters.set(name, (counters.get(name) ?? 0) + n);
+}
+
+/**
+ * Start the event-loop drift probe. Samples actual-vs-expected interval
+ * timing; a tick arriving `>= thresholdMs` late means the loop was blocked.
+ * Also samples RSS each tick to capture peak memory. The timer is `unref`'d
+ * so it never keeps the process alive.
+ */
+export function startDriftProbe(intervalMs = 50, thresholdMs = 50): void {
+	if (!enabled || driftTimer) return;
+	const now = performance.now();
+	drift = {
+		intervalMs,
+		thresholdMs,
+		last: now,
+		start: now,
+		samples: 0,
+		events: 0,
+		maxDriftMs: 0,
+		maxDriftSpan: "",
+		totalBlockedMs: 0,
+	};
+	driftTimer = setInterval(() => {
+		const t = performance.now();
+		const s = drift!;
+		const elapsed = t - s.last;
+		s.last = t;
+		s.samples += 1;
+		const d = elapsed - s.intervalMs;
+		if (d >= s.thresholdMs) {
+			s.events += 1;
+			s.totalBlockedMs += d;
+			if (d > s.maxDriftMs) {
+				s.maxDriftMs = d;
+				s.maxDriftSpan = activeSpans[activeSpans.length - 1] ?? "(none)";
+			}
+		}
+		const rss = process.memoryUsage().rss;
+		if (rss > peakRssBytes) peakRssBytes = rss;
+	}, intervalMs);
+
+	// Don't hold the process open for the probe.
+	(driftTimer as { unref?: () => void }).unref?.();
+}
+
+export function stopDriftProbe(): void {
+	if (driftTimer) {
+		clearInterval(driftTimer);
+		driftTimer = null;
+	}
+}
+
+export interface ProfileReport {
+	phases: Array<{ name: string; totalMs: number; count: number; maxMs: number }>;
+	counters: Record<string, number>;
+	drift: {
+		wallMs: number;
+		samples: number;
+		events: number;
+		maxDriftMs: number;
+		maxDriftSpan: string;
+		totalBlockedMs: number;
+		blockedFraction: number;
+	} | null;
+	peakRssMb: number;
+}
+
+export function getProfileReport(): ProfileReport {
+	const phaseList = Array.from(phases.entries())
+		.map(([name, p]) => ({
+			name,
+			totalMs: Math.round(p.totalMs),
+			count: p.count,
+			maxMs: Math.round(p.maxMs),
+		}))
+		.sort((a, b) => b.totalMs - a.totalMs);
+
+	let driftReport: ProfileReport["drift"] = null;
+	if (drift) {
+		const wallMs = performance.now() - drift.start;
+		driftReport = {
+			wallMs: Math.round(wallMs),
+			samples: drift.samples,
+			events: drift.events,
+			maxDriftMs: Math.round(drift.maxDriftMs),
+			maxDriftSpan: drift.maxDriftSpan,
+			totalBlockedMs: Math.round(drift.totalBlockedMs),
+			blockedFraction: wallMs > 0 ? drift.totalBlockedMs / wallMs : 0,
+		};
+	}
+
+	return {
+		phases: phaseList,
+		counters: Object.fromEntries(counters),
+		drift: driftReport,
+		peakRssMb: Math.round(peakRssBytes / (1024 * 1024)),
+	};
+}
+
+export function resetProfile(): void {
+	phases.clear();
+	counters.clear();
+	peakRssBytes = 0;
+	drift = null;
+}
+
+/**
+ * Write the report to stderr (human table) plus one machine-readable
+ * `PROFILE_JSON {...}` line for the bench harness to parse.
+ */
+export function printProfileReport(label = "sync"): void {
+	if (!enabled) return;
+	const r = getProfileReport();
+	const lines: string[] = [];
+	lines.push(`\n=== pushwork profile: ${label} ===`);
+
+	if (r.drift) {
+		const pct = (r.drift.blockedFraction * 100).toFixed(1);
+		lines.push(
+			`event-loop: wall=${r.drift.wallMs}ms  blocks(>=thresh)=${r.drift.events}` +
+				`  maxDrift=${r.drift.maxDriftMs}ms in [${r.drift.maxDriftSpan}]  blocked=${r.drift.totalBlockedMs}ms (${pct}%)`,
+		);
+	}
+	lines.push(`peak RSS: ${r.peakRssMb} MB`);
+
+	if (r.phases.length > 0) {
+		lines.push("phases (by total ms):");
+		for (const p of r.phases) {
+			lines.push(
+				`  ${p.name.padEnd(28)} ${String(p.totalMs).padStart(8)}ms  ` +
+					`n=${String(p.count).padStart(6)}  max=${p.maxMs}ms`,
+			);
+		}
+	}
+	if (Object.keys(r.counters).length > 0) {
+		lines.push("counters:");
+		for (const [k, v] of Object.entries(r.counters)) {
+			lines.push(`  ${k.padEnd(28)} ${v}`);
+		}
+	}
+
+	process.stderr.write(lines.join("\n") + "\n");
+	process.stderr.write(`PROFILE_JSON ${JSON.stringify(r)}\n`);
+}

--- a/bench/sync-bench.ts
+++ b/bench/sync-bench.ts
@@ -1,0 +1,251 @@
+/**
+ * Offline CPU bench for pushwork's ingest / clone paths.
+ *
+ * Generates a synthetic tree and runs `init` (or `clone`) against a fully
+ * offline Repo (`online:false` ⇒ no sync endpoints), so the measured cost
+ * is *pure local work*: change detection, Automerge document creation, text
+ * splicing, and snapshot (de)serialization. Network time is deliberately
+ * excluded — the timeout/reentrancy behaviour is a separate, server-backed
+ * concern. The drift probe in ./profile records how long the event loop is
+ * blocked in one unbroken synchronous stretch.
+ *
+ * Run with tsx (no build step needed):
+ *
+ *   npx tsx bench/sync-bench.ts --files 2000 --size 512 --text 1 --fanout 20
+ *   npx tsx bench/sync-bench.ts --files 5000 --size 256 --text 0   # binary
+ *   npx tsx bench/sync-bench.ts --clone-local --files 3000         # pull path
+ *   npx tsx bench/sync-bench.ts --clone automerge:... --online      # remote pull
+ *
+ * Flags:
+ *   --files   N    number of files to generate            (default 1000)
+ *   --size    N    bytes per file                          (default 512)
+ *   --text    R    fraction [0..1] of files that are text  (default 1)
+ *   --fanout  N    files per leaf directory                (default 20)
+ *   --shape   S    shape to ingest with                    (default vfs)
+ *   --backend B    "subduction" | "legacy"                 (default subduction)
+ *   --online       sync against the real sync server (default: offline)
+ *   --clone   URL  pull an existing remote root into a fresh dir (online)
+ *   --clone-local  fully offline clone: ingest a tree in a source dir
+ *                  (untimed), copy its storage, then measure the offline pull
+ *   --keep         don't delete the temp dir(s) afterwards
+ *
+ * The profile (event-loop drift, peak RSS) goes to stderr; a one-line JSON
+ * summary goes to stdout.
+ */
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { performance } from "perf_hooks";
+
+import { clone, heads, init, url, type Backend } from "../src/index.js";
+import {
+	getProfileReport,
+	printProfileReport,
+	resetProfile,
+	setProfilingEnabled,
+	startDriftProbe,
+	stopDriftProbe,
+} from "./profile.js";
+
+interface Args {
+	files: number;
+	size: number;
+	text: number;
+	fanout: number;
+	shape: string;
+	backend: Backend;
+	keep: boolean;
+	online: boolean;
+	clone: string;
+	cloneLocal: boolean;
+}
+
+function parseArgs(): Args {
+	const a = process.argv.slice(2);
+	const get = (flag: string, def: string): string => {
+		const i = a.indexOf(flag);
+		return i >= 0 && a[i + 1] !== undefined ? a[i + 1] : def;
+	};
+	return {
+		files: parseInt(get("--files", "1000"), 10),
+		size: parseInt(get("--size", "512"), 10),
+		text: parseFloat(get("--text", "1")),
+		fanout: parseInt(get("--fanout", "20"), 10),
+		shape: get("--shape", "vfs"),
+		backend: get("--backend", "subduction") === "legacy" ? "legacy" : "subduction",
+		keep: a.includes("--keep"),
+		// --online ⇒ sync against the real sync server (prod). Default is
+		// fully offline for a deterministic CPU bench.
+		online: a.includes("--online"),
+		// --clone <url> ⇒ pull the given root URL into a fresh dir (online),
+		// measuring the pull path instead of generating + uploading a tree.
+		clone: get("--clone", ""),
+		// --clone-local ⇒ fully offline clone: generate + ingest a tree in a
+		// source dir (untimed), copy its storage into a fresh dir, then
+		// measure the pull-everything clone from local storage. Isolates the
+		// clone path's CPU (doc materialization) deterministically.
+		cloneLocal: a.includes("--clone-local"),
+	};
+}
+
+function makeTextContent(seedIdx: number, size: number): string {
+	const line =
+		`line ${seedIdx} ` + "lorem ipsum dolor sit amet ".repeat(4) + "\n";
+	let s = "";
+	while (s.length < size) s += line;
+	return s.slice(0, size);
+}
+
+function makeBinaryContent(seedIdx: number, size: number): Buffer {
+	const b = Buffer.allocUnsafe(size);
+	for (let i = 0; i < size; i++) b[i] = (seedIdx * 31 + i * 7) & 0xff;
+	if (size > 0) b[0] = 0; // NUL ⇒ classified binary
+	return b;
+}
+
+async function generateTree(root: string, args: Args): Promise<void> {
+	for (let f = 0; f < args.files; f++) {
+		const d = Math.floor(f / args.fanout);
+		const dir = path.join(root, `d${Math.floor(d / 50)}`, `d${d}`);
+		await fs.mkdir(dir, { recursive: true });
+		const isText = (f % 100) / 100 < args.text;
+		if (isText) {
+			await fs.writeFile(
+				path.join(dir, `f${f}.txt`),
+				makeTextContent(f, args.size),
+			);
+		} else {
+			await fs.writeFile(
+				path.join(dir, `f${f}.bin`),
+				makeBinaryContent(f, args.size),
+			);
+		}
+	}
+}
+
+// Count materialized file leaves (every entry except the "/" root folder).
+async function countLeaves(dir: string): Promise<number> {
+	const entries = await heads(dir);
+	return entries.filter((e) => e.path !== "/").length;
+}
+
+async function mkTmpRoot(prefix: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs();
+	const cloneMode = args.clone.length > 0;
+	const root = await mkTmpRoot("pushwork-bench-");
+	const cleanup: string[] = [root];
+
+	try {
+		// Generate a tree only when ingesting; clone pulls an existing root.
+		let genMs = 0;
+		if (!cloneMode && !args.cloneLocal) {
+			const genStart = performance.now();
+			await generateTree(root, args);
+			genMs = Math.round(performance.now() - genStart);
+		}
+
+		// --clone-local setup (untimed): ingest the tree in a SOURCE dir, then
+		// copy its automerge storage into `root` so the measured clone pulls
+		// everything from local storage.
+		let localCloneUrl: string | undefined;
+		if (args.cloneLocal) {
+			const srcRoot = await mkTmpRoot("pushwork-bench-src-");
+			cleanup.push(srcRoot);
+			await generateTree(srcRoot, args);
+			localCloneUrl = await init({
+				dir: srcRoot,
+				backend: args.backend,
+				shape: args.shape,
+				online: false,
+			});
+			await fs.cp(
+				path.join(srcRoot, ".pushwork", "storage"),
+				path.join(root, ".pushwork", "storage"),
+				{ recursive: true },
+			);
+		}
+
+		// Print the target URL up front for clone modes so it's grabbable even
+		// if the run is interrupted.
+		if (cloneMode) process.stderr.write(`ROOT_URL ${args.clone}\n`);
+		else if (localCloneUrl) process.stderr.write(`ROOT_URL ${localCloneUrl}\n`);
+
+		setProfilingEnabled(true);
+		resetProfile();
+		startDriftProbe();
+		const syncStart = performance.now();
+
+		if (cloneMode) {
+			await clone({
+				url: args.clone,
+				dir: root,
+				backend: args.backend,
+				shape: args.shape,
+				online: true,
+			});
+		} else if (args.cloneLocal) {
+			await clone({
+				url: localCloneUrl!,
+				dir: root,
+				backend: args.backend,
+				shape: args.shape,
+				online: false,
+			});
+		} else {
+			await init({
+				dir: root,
+				backend: args.backend,
+				shape: args.shape,
+				online: args.online,
+			});
+		}
+
+		const syncMs = Math.round(performance.now() - syncStart);
+		stopDriftProbe();
+
+		const rootUrl = await url(root);
+		const filesChanged = await countLeaves(root);
+
+		const mode = cloneMode
+			? "clone"
+			: args.cloneLocal
+				? "clone-local"
+				: args.online
+					? "online"
+					: "offline";
+		printProfileReport(
+			`${mode} files=${filesChanged} size=${args.size}B text=${args.text}`,
+		);
+
+		const summary = {
+			config: args,
+			mode,
+			rootUrl,
+			genMs,
+			syncMs,
+			totalMs: syncMs,
+			filesChanged,
+			success: true,
+			errors: 0,
+			...getProfileReport(),
+		};
+		process.stdout.write(JSON.stringify(summary) + "\n");
+	} finally {
+		if (!args.keep) {
+			for (const dir of cleanup) {
+				await fs.rm(dir, { recursive: true, force: true });
+			}
+		}
+	}
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../dist-bench",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": false
+  },
+  "include": ["**/*.ts", "../src/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
 		"test:coverage": "vitest run --coverage",
 		"lint": "eslint src --ext .ts",
 		"lint:fix": "eslint src --ext .ts --fix",
-		"clean": "rm -rf dist",
+		"clean": "rm -rf dist dist-bench",
 		"prepack": "pnpm run build",
 		"start": "node dist/cli.js",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"bench:build": "tsc -p bench/tsconfig.json",
+		"bench": "pnpm bench:build && node dist-bench/bench/sync-bench.js"
 	},
 	"packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
 	"engines": {

--- a/test/bench/sync-starvation.test.ts
+++ b/test/bench/sync-starvation.test.ts
@@ -1,0 +1,101 @@
+import { execFile } from "child_process";
+import * as path from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Event-loop starvation guard for the ingest path.
+ *
+ * Ingesting a few thousand files makes `pushwork init`/`sync` run thousands
+ * of small synchronous Automerge Wasm calls (doc creation, content splice,
+ * directory mutation) back-to-back with only microtask awaits between them.
+ * Without a macrotask yield, the loop is blocked in one unbroken stretch and
+ * the macrotask queue (timers AND the sync server's socket/pong) is never
+ * serviced — that starvation is what trips a sync server's keepalive and
+ * surfaces as `request timed out`.
+ *
+ * This drives the offline bench (`bench/sync-bench.ts`) in a subprocess —
+ * both to sidestep the Wasm/ESM dual-load that breaks under in-process
+ * transpilers and to measure a real process's event-loop drift. The bench is
+ * compiled to CommonJS (matching the shipped CLI) so the Subduction Wasm
+ * loads as a single consistent instance under Node's `require(ESM)`.
+ *
+ * We assert `maxDriftMs` (the longest *single* block — the thing that misses
+ * pongs), NOT `blockedFraction`: ingest is genuinely CPU-bound, so the
+ * fraction stays high regardless; the question is only whether any one
+ * synchronous stretch runs long enough to trip a sync server's keepalive.
+ *
+ * Gated behind PUSHWORK_BENCH=1 so normal CI stays fast:
+ *   PUSHWORK_BENCH=1 npx vitest run test/bench/sync-starvation
+ */
+const gated = process.env.PUSHWORK_BENCH ? it : it.skip;
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const BENCH_TSCONFIG = path.join(REPO_ROOT, "bench", "tsconfig.json");
+const BENCH = path.join(REPO_ROOT, "dist-bench", "bench", "sync-bench.js");
+
+const FILES = 1500;
+// This branch's per-file async ingest breaks the work into several blocks
+// (longest ~1.5-1.8s at 1500 files), so the threshold guards against a
+// regression to one fully-synchronous multi-second stretch — what actually
+// starves a keepalive — with margin for a noisy box. See .ignore/BENCH-NOTES.md.
+const MAX_BLOCK_MS = 3000;
+
+interface BenchSummary {
+	filesChanged: number;
+	errors: number;
+	drift: {
+		maxDriftMs: number;
+		blockedFraction: number;
+		events: number;
+	} | null;
+}
+
+async function runBench(files: number): Promise<BenchSummary> {
+	const { stdout } = await execFileAsync(
+		"node",
+		[
+			BENCH,
+			"--files",
+			String(files),
+			"--size",
+			"512",
+			"--text",
+			"1",
+			"--fanout",
+			"20",
+		],
+		{ cwd: REPO_ROOT, maxBuffer: 64 * 1024 * 1024 },
+	);
+	const lastLine = stdout.trim().split("\n").pop() ?? "{}";
+	return JSON.parse(lastLine) as BenchSummary;
+}
+
+describe("sync event-loop starvation", () => {
+	// Compile the bench to CJS once before the (gated) run. Skipped work when
+	// the bench gate is off, so normal CI never pays the build cost.
+	beforeAll(async () => {
+		if (!process.env.PUSHWORK_BENCH) return;
+		await execFileAsync("npx", ["tsc", "-p", BENCH_TSCONFIG], {
+			cwd: REPO_ROOT,
+		});
+	}, 120_000);
+
+	gated(
+		`ingesting ${FILES} files must not block the event loop > ${MAX_BLOCK_MS}ms`,
+		async () => {
+			const summary = await runBench(FILES);
+
+			// Sanity: the ingest actually happened.
+			expect(summary.errors).toBe(0);
+			expect(summary.filesChanged).toBe(FILES);
+			expect(summary.drift).not.toBeNull();
+
+			// No single synchronous stretch may starve the loop (and thus the
+			// sync server socket/pong).
+			expect(summary.drift!.maxDriftMs).toBeLessThan(MAX_BLOCK_MS);
+		},
+		120_000,
+	);
+});


### PR DESCRIPTION
As expected, they look about like what v1.x looked like before the perf improvements

```
Offline ingest — init({ online:false }),  512 B/file,  fanout 20
┌───────┬─────────┬────────┬─────────┬───────────┬────────┬──────────┬──────────┐
│ Files │ Content │ gen ms │ sync ms │ max block │ blocks │ blocked% │ peak RSS │
├───────┼─────────┼────────┼─────────┼───────────┼────────┼──────────┼──────────┤
│   500 │ text    │     43 │    1729 │    551 ms │      3 │     16 % │   248 MB │
│  1000 │ text    │     74 │    4462 │   1251 ms │      4 │     29 % │   342 MB │
│  2000 │ text    │    158 │   13303 │   2813 ms │      6 │     35 % │   457 MB │
│  4000 │ text    │    414 │   60527 │  13234 ms │      6 │     26 % │   722 MB │
└───────┴─────────┴────────┴─────────┴───────────┴────────┴──────────┴──────────┘
```

Changes ported from `reliability` _begin_ with #39 