### PR TITLE
Use macrotask-yielding branch of `automerge-repo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
 	],
 	"dependencies": {
 		"@automerge/automerge": "3.3.0-fragments.1",
-		"@automerge/automerge-repo": "2.6.0-subduction.29",
+		"@automerge/automerge-repo": "github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo",
 		"@automerge/automerge-repo-network-websocket": "2.6.0-subduction.29",
-		"@automerge/automerge-repo-storage-nodefs": "2.6.0-subduction.29",
+		"@automerge/automerge-repo-storage-nodefs": "github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo-storage-nodefs",
 		"@automerge/automerge-subduction": "0.15.0",
 		"@commander-js/extra-typings": "^14.0.0",
 		"chalk": "^5.3.0",
@@ -71,10 +71,5 @@
 		"tsx": "^4.19.2",
 		"typescript": "^5.2.0",
 		"vitest": "^2.1.0"
-	},
-	"pnpm": {
-		"overrides": {
-			"@automerge/automerge": "3.3.0-fragments.1"
-		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge-repo': github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo
 
 importers:
 
@@ -101,9 +102,6 @@ packages:
     resolution: {path: packages/automerge-repo-storage-nodefs, tarball: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136}
     version: 2.6.0-subduction.29
     engines: {node: '>=22.13'}
-
-  '@automerge/automerge-repo@2.6.0-subduction.29':
-    resolution: {integrity: sha512-tTx13I4egBCwDeVoSXG8y9+p7O1VDgY0erD67crBJek/oasme32+cchHimE7Tl4Zf5a+5mJ90qMRV5f3J48KcQ==}
 
   '@automerge/automerge-repo@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo':
     resolution: {path: packages/automerge-repo, tarball: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136}
@@ -1243,7 +1241,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.29':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.29
+      '@automerge/automerge-repo': https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo
       cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.4
@@ -1255,25 +1253,7 @@ snapshots:
 
   '@automerge/automerge-repo-storage-nodefs@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo-storage-nodefs':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.29
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo@2.6.0-subduction.29':
-    dependencies:
-      '@automerge/automerge': 3.3.0-fragments.1
-      '@automerge/automerge-subduction': 0.15.0
-      bs58check: 4.0.0
-      cbor-x: 1.6.4
-      debug: 4.4.3
-      eventemitter3: 5.0.4
-      fast-sha256: 1.3.0
-      isomorphic-ws: 5.0.0(ws@8.21.0)
-      uuid: 14.0.0
-      ws: 8.21.0
-      xstate: 5.32.1
+      '@automerge/automerge-repo': https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 3.3.0-fragments.1
         version: 3.3.0-fragments.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.29
-        version: 2.6.0-subduction.29
+        specifier: github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo
+        version: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo
       '@automerge/automerge-repo-network-websocket':
         specifier: 2.6.0-subduction.29
         version: 2.6.0-subduction.29
       '@automerge/automerge-repo-storage-nodefs':
-        specifier: 2.6.0-subduction.29
-        version: 2.6.0-subduction.29
+        specifier: github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo-storage-nodefs
+        version: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo-storage-nodefs
       '@automerge/automerge-subduction':
         specifier: 0.15.0
         version: 0.15.0
@@ -97,11 +97,18 @@ packages:
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.29':
     resolution: {integrity: sha512-M44FxVH01ihg2bLhwuEqnzkLd69I5LRROvRsS2Nf/7kvo4Smxkwr38ATKRc9cEzIF9Hla++6Gsf4Jj7vFgpzug==}
 
-  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.29':
-    resolution: {integrity: sha512-5q0gJxpSu6Qi2LWMMwuQTix5EowQnTiG4wHAY5ywzFyogufDUVOD4pIpVtaw7BMNTtgrMjrcONVZSE/szgs2wQ==}
+  '@automerge/automerge-repo-storage-nodefs@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo-storage-nodefs':
+    resolution: {path: packages/automerge-repo-storage-nodefs, tarball: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136}
+    version: 2.6.0-subduction.29
+    engines: {node: '>=22.13'}
 
   '@automerge/automerge-repo@2.6.0-subduction.29':
     resolution: {integrity: sha512-tTx13I4egBCwDeVoSXG8y9+p7O1VDgY0erD67crBJek/oasme32+cchHimE7Tl4Zf5a+5mJ90qMRV5f3J48KcQ==}
+
+  '@automerge/automerge-repo@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo':
+    resolution: {path: packages/automerge-repo, tarball: https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136}
+    version: 2.6.0-subduction.29
+    engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.15.0':
     resolution: {integrity: sha512-UxD3hfzZoH9yj2/YQZZSr9bJH7R/l+xIIZ9nMPMpsBOAlEFI5AEC4hkVOqC52QOCwq4bcqek0gTYkSWWfNvc2A==}
@@ -1246,7 +1253,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.29':
+  '@automerge/automerge-repo-storage-nodefs@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo-storage-nodefs':
     dependencies:
       '@automerge/automerge-repo': 2.6.0-subduction.29
     transitivePeerDependencies:
@@ -1255,6 +1262,24 @@ snapshots:
       - utf-8-validate
 
   '@automerge/automerge-repo@2.6.0-subduction.29':
+    dependencies:
+      '@automerge/automerge': 3.3.0-fragments.1
+      '@automerge/automerge-subduction': 0.15.0
+      bs58check: 4.0.0
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.4
+      fast-sha256: 1.3.0
+      isomorphic-ws: 5.0.0(ws@8.21.0)
+      uuid: 14.0.0
+      ws: 8.21.0
+      xstate: 5.32.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo@https://codeload.github.com/automerge/automerge-repo/tar.gz/2e8eeb26c4d901b9cd5a995bdea32ff443f25136#path:packages/automerge-repo':
     dependencies:
       '@automerge/automerge': 3.3.0-fragments.1
       '@automerge/automerge-subduction': 0.15.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,26 @@
-allowBuilds:
-  cbor-extract: true
-  esbuild: true
+# pnpm settings live here: pnpm >=10.3x silently ignores the package.json
+# "pnpm" field.
+
+# Force a single @automerge/automerge so the CJS and ESM module graphs share
+# one Wasm instance. Two copies = two Wasm heaps = documents can't be shared
+# across them.
 overrides:
   "@automerge/automerge": 3.3.0-fragments.1
+  # storage-nodefs's git dependency declares its automerge-repo dep by version
+  # (rewritten from workspace:*); redirect it to the same git ref the top-level
+  # dependency uses so there is exactly one automerge-repo copy.
+  "@automerge/automerge-repo": github:automerge/automerge-repo#feed-macrotasks&path:packages/automerge-repo
+
+# The am-repo git dependencies build themselves on install (their `prepare:
+# tsc`; dist/ is gitignored upstream). pnpm blocks dependency build scripts
+# unless allowlisted.
+onlyBuiltDependencies:
+  - "@automerge/automerge-repo"
+  - "@automerge/automerge-repo-storage-nodefs"
+  - cbor-extract
+  - esbuild
+
+# The automerge-repo override above surfaces a git URL as a *sub*dependency
+# (storage-nodefs -> automerge-repo), which pnpm's supply-chain guard blocks by
+# default. We trust this monorepo.
+blockExoticSubdeps: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   cbor-extract: true
   esbuild: true
+overrides:
+  "@automerge/automerge": 3.3.0-fragments.1


### PR DESCRIPTION
Stacked PR over #38 

# Benches + LLM Commentary

> Offline ingest, single sample, dev box (512 B/file, fanout 20):

| files | syncMs 2.6.0-subduction.29 -> feed-macrotasks | maxDriftMs 2.6.0-subduction.29 -> feed-macrotasks |
|-------|-----------------------------------------------|---------------------------------------------------|
| 500   | 1729 -> 2026                                  | 551 -> 655                                        |
| 1000  | 4462 -> 3301                                  | 1251 -> 945                                       |
| 2000  | 13303 -> 7861                                 | 2813 -> 2295                                       |

> feed-macrotasks is faster and blocks less at scale (2000 files: ~41% less wall,
~18% shorter longest block); the win grows with file count (the quadratic-flush
fix). Still multi-second at 2000 — the residual block is partly pushwork's own
`pushFiles`/folder-`encode`, not automerge-repo's feed. Gated guard still passes.

---

[Back to me]
This is still prior to the more radical changes to pushwork's underlying strategy from the `reliability` branch pre-v2.0