### PR TITLE
Cleanup output

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
 		"patches"
 	],
 	"dependencies": {
-		"@automerge/automerge": "3.3.0-fragments.1",
-		"@automerge/automerge-repo": "2.6.0-subduction.37",
-		"@automerge/automerge-repo-network-websocket": "2.6.0-subduction.37",
-		"@automerge/automerge-repo-storage-nodefs": "2.6.0-subduction.37",
+		"@automerge/automerge": "3.3.0-fragments.2",
+		"@automerge/automerge-repo": "2.6.0-subduction.40",
+		"@automerge/automerge-repo-network-websocket": "2.6.0-subduction.40",
+		"@automerge/automerge-repo-storage-nodefs": "2.6.0-subduction.40",
 		"@automerge/automerge-subduction": "0.16.0",
 		"@clack/prompts": "^1.5.1",
 		"@commander-js/extra-typings": "^14.0.0",
@@ -74,7 +74,7 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"@automerge/automerge": "3.3.0-fragments.1"
+			"@automerge/automerge": "3.3.0-fragments.2"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,24 +5,24 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@automerge/automerge': 3.3.0-fragments.1
+  '@automerge/automerge': 3.3.0-fragments.2
 
 importers:
 
   .:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.1
-        version: 3.3.0-fragments.1
+        specifier: 3.3.0-fragments.2
+        version: 3.3.0-fragments.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.37
-        version: 2.6.0-subduction.37
+        specifier: 2.6.0-subduction.40
+        version: 2.6.0-subduction.40
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.37
-        version: 2.6.0-subduction.37
+        specifier: 2.6.0-subduction.40
+        version: 2.6.0-subduction.40
       '@automerge/automerge-repo-storage-nodefs':
-        specifier: 2.6.0-subduction.37
-        version: 2.6.0-subduction.37
+        specifier: 2.6.0-subduction.40
+        version: 2.6.0-subduction.40
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -94,23 +94,23 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
-    resolution: {integrity: sha512-BgxKPgnnEnNgQYUvzinhfnYYNRP0eWhTVgg/ut3JYZdjq7h+OyYrIEiy6eGIkKBn/8USIZKQnvhJH1TXwyfyGg==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.40':
+    resolution: {integrity: sha512-tzMdGgLXgCU3IFRmdisRacAovr3XllwiGVS0y9urYFPdvV3pxanLS2Ozj/YXyMO06UXUnM4YhpU0JzLLhfiI6g==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.37':
-    resolution: {integrity: sha512-XxOYDVe1/YFko/p7wHLRnibIRen/5iWmiGTj7AGdXqfGaETG0t8hZavutThQuKu6m/EZJPVB8kKcs3QYSHJFOg==}
+  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.40':
+    resolution: {integrity: sha512-EfUoXM4SprL4sLYSnbjoTGmBLxk31FITY/EFJvH1ZpyYaLcjqFn8gNS0zcOQD/0JqhaEubwiajQ8g6KBTt6rmw==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.37':
-    resolution: {integrity: sha512-YEnO34sMOKfXkyW0paqfa5BFehXT/VnwMhpxGcLrVLQbGzvXk14uT1vGp//u1wmrFw+iVj++W0E+owA615SbdA==}
+  '@automerge/automerge-repo@2.6.0-subduction.40':
+    resolution: {integrity: sha512-9r3GS8FtZKoIJOtJqkQR0ukF7HSu+IyV5Iqf7MP3ELDz/TEaUbZV8ysyl5Ju4fVZjmagI/n3oH2h4ySk4FdEFQ==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
     resolution: {integrity: sha512-BOOn/4p8cF4LhjDUQdgM3qyZFya+M7ZuZywuC99x/kbhk4UK7dw/QcsifcHG5E1TAW4R/K17ZGFUC5nCVUSSWg==}
 
-  '@automerge/automerge@3.3.0-fragments.1':
-    resolution: {integrity: sha512-Im2n3qcYSuIsLDSjofTRo7CZyyvFn5pKLSCCO5sjWzESw+9q9G25ZIrL2mczDX43cXtyzi+w/4b9VUaiNdY56Q==}
+  '@automerge/automerge@3.3.0-fragments.2':
+    resolution: {integrity: sha512-F5KL+YXD0GMFH/as0/kJ3+lotpuJsH1SSrhhKdYSGtR+S9ytBNTw+s3pAjF2Vr0+ZdTMHxsGjqj5SRkJiSNokQ==}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -1074,8 +1074,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vite-node@2.1.9:
@@ -1169,8 +1169,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xstate@5.32.1:
-    resolution: {integrity: sha512-IGX9q5vEOplWjVq79edfgjJfVV/lXCup9p/fQGgUabAveZrlRwWJ/mC2iZEE7wswXbWITBCoS7gmoFfcuWAwsQ==}
+  xstate@5.32.4:
+    resolution: {integrity: sha512-E5WtDB8DBs2ZWliz2Ry9XfbSZTbBRcK/cwefBot04qQ/L5SLP16xpnTDU4/ZFXuXFhNxi7JP2RhuoGwBnM+S4A==}
 
 snapshots:
 
@@ -1179,9 +1179,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.37':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.37
+      '@automerge/automerge-repo': 2.6.0-subduction.40
       cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.4
@@ -1191,17 +1191,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.37':
+  '@automerge/automerge-repo-storage-nodefs@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.37
+      '@automerge/automerge-repo': 2.6.0-subduction.40
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.37':
+  '@automerge/automerge-repo@2.6.0-subduction.40':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.1
+      '@automerge/automerge': 3.3.0-fragments.2
       '@automerge/automerge-subduction': 0.16.0
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -1209,9 +1209,9 @@ snapshots:
       eventemitter3: 5.0.4
       fast-sha256: 1.3.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      uuid: 14.0.0
+      uuid: 14.0.1
       ws: 8.21.0
-      xstate: 5.32.1
+      xstate: 5.32.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1219,7 +1219,7 @@ snapshots:
 
   '@automerge/automerge-subduction@0.16.0': {}
 
-  '@automerge/automerge@3.3.0-fragments.1': {}
+  '@automerge/automerge@3.3.0-fragments.2': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -2002,7 +2002,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  uuid@14.0.0: {}
+  uuid@14.0.1: {}
 
   vite-node@2.1.9(@types/node@20.19.43):
     dependencies:
@@ -2089,4 +2089,4 @@ snapshots:
 
   ws@8.21.0: {}
 
-  xstate@5.32.1: {}
+  xstate@5.32.4: {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,13 @@ import {
 } from "./pushwork.js";
 import { log } from "./log.js";
 import { out } from "./output.js";
-import { legacyUrl, subductionUrl, type SyncSnapshot } from "./repo.js";
+import {
+	isTransportError,
+	legacyUrl,
+	setAmrepoErrorSink,
+	subductionUrl,
+	type SyncSnapshot,
+} from "./repo.js";
 import { formatVersions } from "./version.js";
 import { migrate, versionLabel } from "./migrations.js";
 
@@ -32,6 +38,39 @@ process.on("warning", (w) => {
 	if (w.name === "TimeoutNegativeWarning") return;
 	if (priorWarn.length > 0) for (const l of priorWarn) l.call(process, w);
 	else process.stderr.write(`(node:${process.pid}) ${w.name}: ${w.message}\n`);
+});
+
+// A dropped connection can surface as an async error with no local listener;
+// suppress those transport blips (Node would otherwise dump a stack trace or
+// exit), and let genuine faults through.
+process.on("uncaughtException", (err) => {
+	if (isTransportError(err)) {
+		dlog("suppressed uncaught transport error: %s", err.message);
+		return;
+	}
+	out.error(err);
+	out.exit(1);
+});
+process.on("unhandledRejection", (reason) => {
+	if (isTransportError(reason)) {
+		dlog(
+			"suppressed transport rejection: %s",
+			reason instanceof Error ? reason.message : String(reason),
+		);
+		return;
+	}
+	out.error(reason instanceof Error ? reason : String(reason));
+	out.exit(1);
+});
+
+// am-repo logs are silent by default (see openRepo); surface genuine `error`s in
+// the UI. Main process only — workers keep logs out of the parent's output.
+setAmrepoErrorSink((namespace, message, ...args) => {
+	const tag = namespace.replace(/^automerge-repo:/, "");
+	const detail = args
+		.map((a) => (a instanceof Error ? a.message : String(a)))
+		.join(" ");
+	out.warn(`${tag}: ${message}${detail ? ` ${detail}` : ""}`);
 });
 
 const collect = (value: string, prev: string[] | undefined) =>
@@ -78,13 +117,22 @@ const fmtHeads = (heads: string[]) => (heads.length ? heads.join(" ") : "(none)"
 function reportSync(sync: SyncSnapshot | undefined): void {
 	if (!sync) return;
 	if (out.isPorcelain) {
-		out.log(`sync\t${sync.synced ? "synced" : sync.connected ? "behind" : "offline"}`);
+		out.log(
+			`sync\t${sync.synced ? "synced" : sync.pending ? "pending" : sync.connected ? "behind" : "offline"}`,
+		);
+		out.log(`connect\t${sync.connectMs ?? ""}`);
 		out.log(`root\t${sync.url}\t${sync.localHeads.join(" ")}`);
 		out.log(`server\t${sync.serverPeerId ?? ""}\t${sync.serverHeads.join(" ")}`);
 		return;
 	}
 	out.block(
-		sync.synced ? "SYNCED" : sync.connected ? "NOT SYNCED" : "OFFLINE",
+		sync.synced
+			? "SYNCED"
+			: sync.pending
+				? "PENDING"
+				: sync.connected
+					? "NOT SYNCED"
+					: "OFFLINE",
 	);
 	out.obj({
 		"root doc": sync.url,

--- a/src/pushwork.ts
+++ b/src/pushwork.ts
@@ -29,8 +29,11 @@ import {
 import { log } from "./log.js";
 import {
 	openRepo,
+	safeShutdown,
+	waitForConnection,
 	waitForSync,
 	waitForServerSync,
+	type Connection,
 	type SyncSnapshot,
 } from "./repo.js";
 import {
@@ -186,6 +189,8 @@ export async function init(
 	await fs.mkdir(pushworkDir(root), { recursive: true });
 
 	const repo = await openRepo(opts.backend, storageDir(root), { offline: !online });
+	// Start measuring the connection now so the local walk/encode overlaps it.
+	const connWait = online ? waitForConnection(repo, opts.backend) : undefined;
 	try {
 		const shape = await resolveShape(opts.shape);
 		const ig = await loadIgnore(root);
@@ -209,7 +214,9 @@ export async function init(
 
 		let sync: SyncSnapshot | undefined;
 		if (online) {
-			report("Publishing to sync server");
+			report(
+				`Publishing ${fsFiles.size} ${fsFiles.size === 1 ? "file" : "files"} to the sync server`,
+			);
 			stampLastSyncAt(folderHandle);
 			sync = await waitForServerSync(repo, folderHandle, opts.backend, {
 				idleMs: 1500,
@@ -224,10 +231,11 @@ export async function init(
 			shape: opts.shape,
 			artifactDirectories: artifactDirs,
 		});
+		await attachConnectMs(sync, connWait);
 		dlog("init complete: rootUrl=%s files=%d synced=%s", folderUrl, fsFiles.size, sync?.synced);
 		return { url: folderUrl, files: fsFiles.size, sync };
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -248,6 +256,7 @@ export async function clone(
 
 	const online = opts.online ?? true;
 	const repo = await openRepo(opts.backend, storageDir(root), { offline: !online });
+	const connWait = online ? waitForConnection(repo, opts.backend) : undefined;
 	try {
 		report("Fetching repository");
 		let folderHandle = await repo.find<unknown>(opts.url as AutomergeUrl);
@@ -316,10 +325,11 @@ export async function clone(
 			shape: shapeName,
 			artifactDirectories: artifactDirs,
 		});
+		await attachConnectMs(sync, connWait);
 		dlog("clone complete files=%d synced=%s", fileCount, sync?.synced);
 		return { url: storedUrl, files: fileCount, sync };
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -439,7 +449,7 @@ async function openDetachedRepo(
 		const repo = await openRepo(resolved, storageDir(root), {
 			offline: false,
 		});
-		return { repo, backend: resolved, cleanup: () => repo.shutdown() };
+		return { repo, backend: resolved, cleanup: () => safeShutdown(repo) };
 	}
 	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "pushwork-"));
 	dlog("openDetachedRepo no config; ephemeral storage=%s", tmp);
@@ -449,7 +459,7 @@ async function openDetachedRepo(
 		repo,
 		backend: resolved,
 		cleanup: async () => {
-			await repo.shutdown();
+			await safeShutdown(repo);
 			await fs.rm(tmp, { recursive: true, force: true });
 		},
 	};
@@ -577,6 +587,7 @@ async function publishCurrentTree(cwd: string): Promise<SyncSnapshot | undefined
 	dlog("publish root=%s", root);
 
 	const repo = await openRepo(config.backend, storageDir(root), { offline: false });
+	const connWait = waitForConnection(repo, config.backend);
 	try {
 		const shape = await resolveShape(config.shape);
 		const folderHandle = await repo.find<unknown>(config.rootUrl);
@@ -590,10 +601,11 @@ async function publishCurrentTree(cwd: string): Promise<SyncSnapshot | undefined
 			idleMs: 1500,
 			maxMs: 15000,
 		});
+		await attachConnectMs(sync, connWait);
 		dlog("publish complete synced=%s", sync.synced);
 		return sync;
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -658,7 +670,7 @@ export async function nuclearizeRepo(
 			isArtifactDir: isArtifactPath,
 		});
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -688,6 +700,7 @@ async function commitWorkdir(
 	const repo = await openRepo(config.backend, storageDir(root), {
 		offline: !online,
 	});
+	const connWait = online ? waitForConnection(repo, config.backend) : undefined;
 	try {
 		const shape = await resolveShape(config.shape);
 		const folderHandle = await repo.find<unknown>(config.rootUrl);
@@ -720,41 +733,45 @@ async function commitWorkdir(
 		let sync: SyncSnapshot | undefined;
 		if (online) {
 			report("Syncing with peers");
-			// First catch up to the server (we hold everything it advertises)
-			// before refreshing pins, so pinned leaves capture each file doc's
-			// post-merge heads.
-			await waitForServerSync(repo, folderHandle, config.backend, {
-				idleMs: 1500,
-				maxMs: 15000,
-			});
+			// Only artifact (pinned) leaves need a pre-refresh catch-up (to pin to
+			// the server's merged heads). No artifacts → the single confirm-wait
+			// below both pulls peer changes and pushes our stamp.
+			const hasArtifacts = [...flattenLeaves(newTree).keys()].some(isArtifactPath);
 
-			// After peer changes have settled, refresh the folder doc so its
-			// pinned (artifact) leaves reference each file doc's current
-			// heads. Bare URLs already track current heads implicitly.
-			const refreshed = await refreshFolderPins(
-				repo,
-				folderHandle,
-				shape,
-				isArtifactPath,
-			);
+			let refreshed = false;
+			if (hasArtifacts) {
+				// Catch up so the re-pin captures each file doc's post-merge heads.
+				await waitForServerSync(repo, folderHandle, config.backend, {
+					idleMs: 1500,
+					maxMs: 15000,
+				});
+				// Bare URLs already track current heads implicitly; only pins move.
+				refreshed = await refreshFolderPins(
+					repo,
+					folderHandle,
+					shape,
+					isArtifactPath,
+				);
+			}
 
 			// Always stamp lastSyncAt — a sync is also a checkpoint that
-			// "we reconciled with the server at this time" — and re-confirm the
+			// "we reconciled with the server at this time" — then confirm the
 			// server has caught up to the stamped (and any refreshed) state.
 			stampLastSyncAt(folderHandle);
 			sync = await waitForServerSync(repo, folderHandle, config.backend, {
 				idleMs: 1500,
-				maxMs: refreshed ? 10000 : 5000,
+				maxMs: refreshed ? 10000 : hasArtifacts ? 5000 : 15000,
 			});
 		}
 
 		if (online) report("Writing changes");
 		const finalTree = await shape.decode({ repo, root: folderHandle });
 		await materializeTree(repo, root, finalTree);
+		await attachConnectMs(sync, connWait);
 		dlog("commit complete synced=%s", sync?.synced);
 		return sync;
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -809,7 +826,7 @@ export async function heads(
 		out.sort((a, b) => a.path.localeCompare(b.path));
 		return out;
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -838,7 +855,7 @@ export async function status(cwd: string): Promise<{ diff: Diff }> {
 		const diff = computeDiff(previousFiles, fsFiles);
 		return { diff };
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -875,7 +892,7 @@ export async function diff(
 		}
 		return out;
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -934,7 +951,7 @@ export async function cutWorkdir(
 		dlog("cut complete id=%d entries=%d", snarf.id, entries.length);
 		return { id: snarf.id, entries: entries.length };
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 }
 
@@ -966,7 +983,7 @@ export async function pasteSnarf(
 			);
 		}
 	} finally {
-		await repo.shutdown();
+		await safeShutdown(repo);
 	}
 
 	const snarf = await takeSnarf(root, selector);
@@ -1007,6 +1024,22 @@ function stampLastSyncAt(handle: DocHandle<unknown>): void {
 	(handle as DocHandle<Stamped>).change((d: Stamped) => {
 		d.lastSyncAt = Date.now();
 	});
+}
+
+/**
+ * Await the connection probe started at repo-open and stamp its measured connect
+ * time (and any server peer id) onto the sync snapshot.
+ */
+async function attachConnectMs(
+	sync: SyncSnapshot | undefined,
+	connWait: Promise<Connection> | undefined,
+): Promise<void> {
+	if (!connWait) return;
+	const conn = await connWait;
+	if (sync) {
+		sync.connectMs = conn.connectMs;
+		if (sync.serverPeerId == null) sync.serverPeerId = conn.serverPeerId;
+	}
 }
 
 function normalizeDirs(dirs: readonly string[]): string[] {

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,16 +1,54 @@
 import {
 	Repo,
 	initSubduction,
+	setLoggerFactory,
 	type AutomergeUrl,
 	type DocHandle,
 	type NetworkAdapterInterface,
 } from "@automerge/automerge-repo";
 import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import debug from "debug";
 import type { Backend } from "./config.js";
 import { log } from "./log.js";
 
 const dlog = log("repo");
+
+// Where automerge-repo `error`-level logs go. Default: silent (routed to
+// `debug`). The main CLI overrides it (setAmrepoErrorSink) to surface failures;
+// workers keep the silent default so they never write to the parent's output.
+type AmrepoErrorSink = (
+	namespace: string,
+	message: string,
+	...args: unknown[]
+) => void;
+let amrepoErrorSink: AmrepoErrorSink = (namespace, message, ...args) =>
+	debug(namespace)(message, ...args);
+
+/** Route automerge-repo `error`-level logs somewhere visible (e.g. the CLI UI). */
+export function setAmrepoErrorSink(sink: AmrepoErrorSink): void {
+	amrepoErrorSink = sink;
+}
+
+// Route automerge-repo logging through `debug` (silent by default; opt in with
+// `DEBUG=automerge-repo:subduction:*`), except `error` → the sink above.
+// Installed in openRepo so it also covers the shard worker threads.
+let amrepoLoggingInstalled = false;
+function installAmrepoLogging(): void {
+	if (amrepoLoggingInstalled) return;
+	amrepoLoggingInstalled = true;
+	setLoggerFactory((namespace) => {
+		const trace = debug(namespace);
+		const to = (message: string, ...args: unknown[]) => trace(message, ...args);
+		return {
+			debug: to,
+			info: to,
+			warn: to,
+			error: (message: string, ...args: unknown[]) =>
+				amrepoErrorSink(namespace, message, ...args),
+		};
+	});
+}
 
 const DEFAULT_LEGACY = "wss://sync3.automerge.org";
 const DEFAULT_SUBDUCTION = "wss://subduction.sync.inkandswitch.com";
@@ -26,6 +64,7 @@ export async function openRepo(
 	opts: { offline?: boolean } = {},
 ): Promise<Repo> {
 	dlog("openRepo backend=%s storage=%s offline=%s", backend, storageDir, !!opts.offline);
+	installAmrepoLogging();
 	await initSubduction();
 	const storage = new NodeFSStorageAdapter(storageDir);
 	if (opts.offline) {
@@ -48,6 +87,81 @@ export async function openRepo(
 	});
 }
 
+// Above am-repo's own ~5s shutdown quiesce (so last-mile delivery completes),
+// but well under the ~60s stall a stuck roundtrip or reconnect can cause.
+const DEFAULT_SHUTDOWN_MS = 15000;
+
+/**
+ * Shut a repo down without a slow/dropped connection hanging the CLI: race
+ * `repo.shutdown()` against a bounded deadline, then continue (process exit
+ * closes any lingering socket). Teardown errors are ignored — the work is
+ * already done. Override with `PUSHWORK_SHUTDOWN_MS` (`0` = unbounded).
+ */
+export async function safeShutdown(
+	repo: Repo,
+	{ maxMs }: { maxMs?: number } = {},
+): Promise<void> {
+	const envRaw = process.env.PUSHWORK_SHUTDOWN_MS;
+	const env = envRaw == null ? Number.NaN : Number(envRaw);
+	const deadline = maxMs ?? (Number.isFinite(env) ? env : DEFAULT_SHUTDOWN_MS);
+
+	// Never rejects: teardown hiccups (transport or otherwise) go to debug only.
+	const shutdown = (async () => {
+		try {
+			await repo.shutdown();
+		} catch (err) {
+			dlog(
+				"safeShutdown: ignored %s during shutdown: %s",
+				isTransportError(err) ? "transport error" : "error",
+				errMessage(err),
+			);
+		}
+	})();
+
+	if (deadline <= 0) {
+		await shutdown;
+		return;
+	}
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const bound = new Promise<void>((resolve) => {
+		timer = setTimeout(() => {
+			dlog("safeShutdown: exceeded %dms; continuing (exit closes sockets)", deadline);
+			resolve();
+		}, deadline);
+	});
+	try {
+		await Promise.race([shutdown, bound]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+/**
+ * Whether an error is a network/transport blip (dropped WebSocket, reset/refused
+ * socket, DNS hiccup, …) — expected on flaky links and during teardown, so
+ * callers suppress it rather than fail the command.
+ */
+export function isTransportError(err: unknown): boolean {
+	const msg = errMessage(err).toLowerCase();
+	return (
+		msg.includes("websocket") ||
+		msg.includes("socket hang up") ||
+		msg.includes("econnreset") ||
+		msg.includes("econnrefused") ||
+		msg.includes("econnaborted") ||
+		msg.includes("epipe") ||
+		msg.includes("etimedout") ||
+		msg.includes("enotfound") ||
+		msg.includes("eai_again") ||
+		msg.includes("unexpected server response") ||
+		msg.includes("ws error")
+	);
+}
+
+const errMessage = (err: unknown): string =>
+	err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
@@ -58,8 +172,20 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 export type SyncSnapshot = {
 	/** The document this snapshot describes (the root folder doc, for `sync`). */
 	url: AutomergeUrl;
-	/** True once we hold every commit the sync server last advertised for the doc. */
+	/**
+	 * True only when confirmed both ways: we hold every commit the server
+	 * advertised AND it has advertised our frontier back (push-confirmed). Never
+	 * true on a bare pull-settle, so the CLI won't print SYNCED before our change
+	 * has demonstrably landed.
+	 */
 	synced: boolean;
+	/**
+	 * Connected and pull-complete, but our push wasn't confirmed before the
+	 * deadline — shown as PENDING. Usually transient; can be a false-negative if
+	 * the server compacted our change into a differently-id'd fragment (see
+	 * `.ignore/FIXME.md`).
+	 */
+	pending: boolean;
 	/** Whether the repo currently has a live Subduction connection to a server. */
 	connected: boolean;
 	/** The sync server's peer id (its verifying key), once the handshake is done. */
@@ -68,6 +194,12 @@ export type SyncSnapshot = {
 	localHeads: string[];
 	/** The heads the server last advertised for the doc (Subduction sedimentree heads). */
 	serverHeads: string[];
+	/**
+	 * How long the Subduction connection took this run (ms, from repo open to the
+	 * `subduction-connection` handshake). `0` if already connected; undefined on
+	 * legacy or if we never connected.
+	 */
+	connectMs?: number;
 };
 
 // The connected sync-server peer id (its verifying key), or undefined while the
@@ -79,6 +211,53 @@ async function connectedServerPeer(repo: Repo): Promise<string | undefined> {
 	} catch {
 		return undefined; // no Subduction source
 	}
+}
+
+export type Connection = {
+	connected: boolean;
+	/** ms from this call until the connection was established (0 if already up). */
+	connectMs: number;
+	serverPeerId?: string;
+};
+
+/**
+ * Resolve once the repo's Subduction connection is established, reporting how
+ * long the handshake took (via the `subduction-connection` event). Resolves
+ * connected=false after `maxMs` instead of hanging; returns immediately on
+ * legacy. Elapsed is measured from the call, so starting it right after
+ * {@link openRepo} lets local work overlap the connect.
+ */
+export async function waitForConnection(
+	repo: Repo,
+	backend: Backend,
+	{ maxMs = 15000 }: { maxMs?: number } = {},
+): Promise<Connection> {
+	const start = Date.now();
+	if (backend !== "subduction") return { connected: false, connectMs: 0 };
+	if (repo.isSubductionConnected()) {
+		return { connected: true, connectMs: 0, serverPeerId: await connectedServerPeer(repo) };
+	}
+
+	const connected = await new Promise<boolean>((resolve) => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const onConn = (p: { connected: boolean }) => {
+			if (!p.connected) return;
+			if (timer) clearTimeout(timer);
+			repo.off("subduction-connection", onConn);
+			resolve(true);
+		};
+		repo.on("subduction-connection", onConn);
+		timer = setTimeout(() => {
+			repo.off("subduction-connection", onConn);
+			resolve(repo.isSubductionConnected());
+		}, maxMs);
+	});
+
+	return {
+		connected,
+		connectMs: Date.now() - start,
+		serverPeerId: connected ? await connectedServerPeer(repo) : undefined,
+	};
 }
 
 // Trim a peer's advertised heads for *display*. The sync server advertises
@@ -122,6 +301,46 @@ function sleepOrWake(
 	});
 }
 
+// Docs already nudged for a resync this run, keyed by repo, so the several
+// waitForServerSync calls in one command don't re-fire `resyncSubduction` on the
+// same doc. One nudge per doc per run; am-repo's heal loop handles the rest.
+const resyncedDocs = new WeakMap<Repo, Set<string>>();
+
+// Returns true the first time a given doc is nudged for this repo, false after.
+// Exported for unit testing the dedup; not part of the public API.
+export function claimResync(repo: Repo, documentId: string): boolean {
+	let seen = resyncedDocs.get(repo);
+	if (!seen) {
+		seen = new Set<string>();
+		resyncedDocs.set(repo, seen);
+	}
+	if (seen.has(documentId)) return false;
+	seen.add(documentId);
+	return true;
+}
+
+/**
+ * The two-directional sync verdict: `synced` when settled, pull-complete, and the
+ * server has advertised our frontier back (push-confirmed); `pending` when
+ * settled and pull-complete but not yet push-confirmed. Both false while behind
+ * or unsettled.
+ */
+export function syncVerdict(args: {
+	localQuiet: boolean;
+	pullComplete: boolean;
+	frontier: readonly string[];
+	advertised: readonly string[];
+}): { synced: boolean; pending: boolean } {
+	const advertised = new Set(args.advertised);
+	const pushConfirmed =
+		args.frontier.length > 0 && args.frontier.every((h) => advertised.has(h));
+	const settledAndCaughtUp = args.localQuiet && args.pullComplete;
+	return {
+		synced: settledAndCaughtUp && pushConfirmed,
+		pending: settledAndCaughtUp && !pushConfirmed,
+	};
+}
+
 /**
  * Wait until `handle` is in sync with the Subduction sync server, judging
  * "synced" against the *server's* advertised heads rather than a local-settle
@@ -160,6 +379,7 @@ export async function waitForServerSync<T>(
 		return {
 			url: handle.url,
 			synced: true,
+			pending: false,
 			connected: false,
 			localHeads: headsOf(),
 			serverHeads: [],
@@ -195,12 +415,16 @@ export async function waitForServerSync<T>(
 			const serverPeerId = await connectedServerPeer(repo);
 			let serverHeads: string[] = [];
 			let synced = false;
+			let pending = false;
 			if (serverPeerId) {
 				const info = handle.getSyncInfo(serverPeerId as never);
 				if (info && info.lastHeads.length > 0) {
-					// The synced verdict uses the FULL advertised set: do we
-					// already hold every commit the server has?
-					synced = localQuiet && handle.containsHeads(info.lastHeads);
+					({ synced, pending } = syncVerdict({
+						localQuiet,
+						pullComplete: handle.containsHeads(info.lastHeads),
+						frontier: headsOf(),
+						advertised: info.lastHeads,
+					}));
 					// For display, trim the sedimentree heads down to our frontier
 					// tip(s) plus anything we genuinely lack, so the reported
 					// server heads line up with localHeads (and match once synced).
@@ -211,13 +435,14 @@ export async function waitForServerSync<T>(
 			if (synced || now - start >= maxMs) {
 				dlog(
 					"waitForServerSync %s url=%s elapsed=%dms",
-					synced ? "synced" : "timed out",
+					synced ? "synced" : pending ? "pending" : "timed out",
 					handle.url,
 					now - start,
 				);
 				return {
 					url: handle.url,
 					synced,
+					pending: synced ? false : pending,
 					connected: repo.isSubductionConnected(),
 					serverPeerId,
 					localHeads: headsOf(),
@@ -229,13 +454,17 @@ export async function waitForServerSync<T>(
 			// single fresh sync round (the technique's stuck-doc nudge, without the
 			// full per-doc exponential backoff a long-lived client would keep).
 			if (!resynced && serverPeerId && now - start >= resyncAfterMs) {
-				dlog("waitForServerSync nudging resync url=%s", handle.url);
-				try {
-					repo.resyncSubduction(documentId);
-				} catch {
-					// no Subduction source / doc not attached
+				resynced = true; // don't reconsider within this call regardless
+				if (claimResync(repo, documentId)) {
+					dlog("waitForServerSync nudging resync url=%s", handle.url);
+					try {
+						repo.resyncSubduction(documentId);
+					} catch {
+						// no Subduction source / doc not attached
+					}
+				} else {
+					dlog("waitForServerSync resync already nudged this run url=%s", handle.url);
 				}
-				resynced = true;
 			}
 
 			await sleepOrWake(pollMs, (fn) => {

--- a/test/integration/resilience.test.ts
+++ b/test/integration/resilience.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Resilience guard: with an unreachable sync server, `pushwork init` must finish
+ * promptly (not hang on teardown), report an honest not-synced verdict, and keep
+ * the sync layer's connection logs out of the CLI output.
+ *
+ * Uses a *sharded* init so the guard also covers the worker threads (each opens
+ * its own Repo, so log suppression must live in openRepo, not only the CLI).
+ * Network-free: the endpoint is a closed localhost port (immediate ECONNREFUSED).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as tmp from "tmp";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileP = promisify(execFile);
+const CLI = path.join(__dirname, "..", "..", "dist", "cli.js");
+
+// A closed port on loopback → immediate ECONNREFUSED, no DNS, no real network.
+const DEAD_SERVER = "ws://127.0.0.1:1";
+
+tmp.setGracefulCleanup();
+
+describe("unreachable sync server", () => {
+	it(
+		"sharded init finishes promptly, reports offline, and stays quiet (main + workers)",
+		async () => {
+			const dir = tmp.dirSync({ unsafeCleanup: true }).name;
+			// Enough files to trip the shard-ingest worker pool (SHARD_MIN_ITEMS=8).
+			await Promise.all(
+				Array.from({ length: 40 }, (_, i) =>
+					fs.writeFile(path.join(dir, `file_${i}.txt`), `content ${i}\n`),
+				),
+			);
+
+			const start = Date.now();
+			const { stdout, stderr } = await execFileP(
+				"node",
+				[CLI, "--porcelain", "init", dir],
+				{
+					cwd: dir,
+					env: {
+						...process.env,
+						PUSHWORK_SUBDUCTION_SERVER: DEAD_SERVER,
+						PUSHWORK_PARALLEL_INGEST: "shard",
+						FORCE_COLOR: "0",
+						NO_COLOR: "1",
+					},
+					timeout: 50_000,
+					maxBuffer: 16 * 1024 * 1024,
+				},
+			);
+			const elapsed = Date.now() - start;
+			const output = stdout + stderr;
+
+			// (a) didn't hang
+			expect(elapsed).toBeLessThan(45_000);
+			expect(stdout).toContain("INITIALIZED");
+			// (b) honest verdict: offline, not a false synced
+			expect(stdout).toContain("sync\toffline");
+			expect(stdout).not.toContain("sync\tsynced");
+			// (c) no connection-log spam (main or workers), no unhandled fault
+			expect(output).not.toContain("[automerge-repo:subduction");
+			expect(stderr).not.toMatch(/UnhandledPromiseRejection|Uncaught|unhandledRejection/);
+		},
+		50_000,
+	);
+});

--- a/test/unit/sync-helpers.test.ts
+++ b/test/unit/sync-helpers.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for the sync-reliability helpers in `src/repo.ts` (isTransportError,
+ * syncVerdict, claimResync, safeShutdown, waitForConnection). Fully offline —
+ * safeShutdown/waitForConnection run against a tiny fake repo.
+ */
+import { describe, it, expect } from "vitest";
+import type { Repo } from "@automerge/automerge-repo";
+import {
+	claimResync,
+	isTransportError,
+	safeShutdown,
+	syncVerdict,
+	waitForConnection,
+} from "../../src/repo.js";
+
+describe("isTransportError", () => {
+	it("classifies dropped-connection blips as transport errors", () => {
+		for (const e of [
+			new Error("WebSocket is not open: readyState 3 (CLOSING)"),
+			new Error("socket hang up"),
+			new Error("read ECONNRESET"),
+			new Error("connect ECONNREFUSED 127.0.0.1:443"),
+			new Error("getaddrinfo ENOTFOUND sync.example.com"),
+			new Error("Unexpected server response: 502"),
+			"write EPIPE",
+		]) {
+			expect(isTransportError(e)).toBe(true);
+		}
+	});
+
+	it("does not swallow genuine application errors", () => {
+		for (const e of [
+			new Error("pushwork already initialized at /tmp/x"),
+			new Error("invalid automerge URL"),
+			"nothing to cut: working tree clean",
+			undefined,
+			null,
+			42,
+		]) {
+			expect(isTransportError(e)).toBe(false);
+		}
+	});
+});
+
+describe("syncVerdict", () => {
+	const base = { localQuiet: true, pullComplete: true } as const;
+
+	it("is synced only when settled, pull-complete, and push-confirmed", () => {
+		expect(
+			syncVerdict({ ...base, frontier: ["a", "b"], advertised: ["a", "b", "frag"] }),
+		).toEqual({ synced: true, pending: false });
+	});
+
+	it("is pending when our frontier isn't advertised back yet", () => {
+		expect(
+			syncVerdict({ ...base, frontier: ["a", "b"], advertised: ["a"] }),
+		).toEqual({ synced: false, pending: true });
+	});
+
+	it("is neither synced nor pending while still behind (pull incomplete)", () => {
+		expect(
+			syncVerdict({
+				localQuiet: true,
+				pullComplete: false,
+				frontier: ["a"],
+				advertised: ["a"],
+			}),
+		).toEqual({ synced: false, pending: false });
+	});
+
+	it("is neither while local heads are still unsettled", () => {
+		expect(
+			syncVerdict({
+				localQuiet: false,
+				pullComplete: true,
+				frontier: ["a"],
+				advertised: ["a"],
+			}),
+		).toEqual({ synced: false, pending: false });
+	});
+});
+
+describe("claimResync", () => {
+	it("returns true once per (repo, doc), then false", () => {
+		const repoA = {} as unknown as Repo;
+		const repoB = {} as unknown as Repo;
+
+		expect(claimResync(repoA, "doc1")).toBe(true);
+		expect(claimResync(repoA, "doc1")).toBe(false);
+		// A different doc on the same repo is independent.
+		expect(claimResync(repoA, "doc2")).toBe(true);
+		// A different repo is independent.
+		expect(claimResync(repoB, "doc1")).toBe(true);
+		expect(claimResync(repoB, "doc1")).toBe(false);
+	});
+});
+
+// ── Fake repo for teardown / connection timing ────────────────────────────
+
+type Handler = (...args: unknown[]) => void;
+
+function fakeRepo(init: {
+	shutdown?: () => Promise<void>;
+	connected?: boolean;
+	peerIds?: string[];
+}) {
+	let connected = init.connected ?? false;
+	const listeners = new Map<string, Set<Handler>>();
+	const repo = {
+		shutdown: init.shutdown ?? (async () => {}),
+		isSubductionConnected: () => connected,
+		connectedSubductionPeerIds: async () => init.peerIds ?? [],
+		on: (event: string, fn: Handler) => {
+			(listeners.get(event) ?? listeners.set(event, new Set()).get(event)!).add(fn);
+		},
+		off: (event: string, fn: Handler) => {
+			listeners.get(event)?.delete(fn);
+		},
+	};
+	return {
+		repo: repo as unknown as Repo,
+		emitConnection(value: boolean) {
+			connected = value;
+			for (const fn of listeners.get("subduction-connection") ?? []) {
+				fn({ connected: value });
+			}
+		},
+		listenerCount() {
+			return listeners.get("subduction-connection")?.size ?? 0;
+		},
+	};
+}
+
+describe("safeShutdown", () => {
+	it("returns promptly even when repo.shutdown() hangs forever", async () => {
+		const { repo } = fakeRepo({ shutdown: () => new Promise<void>(() => {}) });
+		const start = Date.now();
+		await safeShutdown(repo, { maxMs: 100 });
+		const elapsed = Date.now() - start;
+		expect(elapsed).toBeGreaterThanOrEqual(80);
+		expect(elapsed).toBeLessThan(2000); // nowhere near the ~1-minute hang
+	});
+
+	it("swallows a WebSocket error thrown during shutdown", async () => {
+		const { repo } = fakeRepo({
+			shutdown: async () => {
+				throw new Error("WebSocket was closed before the connection was established");
+			},
+		});
+		await expect(safeShutdown(repo, { maxMs: 1000 })).resolves.toBeUndefined();
+	});
+
+	it("resolves immediately on a clean shutdown", async () => {
+		let called = false;
+		const { repo } = fakeRepo({
+			shutdown: async () => {
+				called = true;
+			},
+		});
+		const start = Date.now();
+		await safeShutdown(repo, { maxMs: 5000 });
+		expect(called).toBe(true);
+		expect(Date.now() - start).toBeLessThan(1000);
+	});
+});
+
+describe("waitForConnection", () => {
+	it("short-circuits on the legacy backend (no Subduction source)", async () => {
+		const { repo } = fakeRepo({});
+		await expect(waitForConnection(repo, "legacy")).resolves.toEqual({
+			connected: false,
+			connectMs: 0,
+		});
+	});
+
+	it("reports 0ms and the server peer when already connected", async () => {
+		const { repo } = fakeRepo({ connected: true, peerIds: ["server-peer"] });
+		const conn = await waitForConnection(repo, "subduction");
+		expect(conn).toEqual({
+			connected: true,
+			connectMs: 0,
+			serverPeerId: "server-peer",
+		});
+	});
+
+	it("resolves when the connection event fires, timing the handshake", async () => {
+		const fake = fakeRepo({ peerIds: ["server-peer"] });
+		const p = waitForConnection(fake.repo, "subduction", { maxMs: 5000 });
+		setTimeout(() => fake.emitConnection(true), 60);
+		const conn = await p;
+		expect(conn.connected).toBe(true);
+		expect(conn.serverPeerId).toBe("server-peer");
+		expect(conn.connectMs).toBeGreaterThanOrEqual(40);
+		expect(conn.connectMs).toBeLessThan(2000);
+		expect(fake.listenerCount()).toBe(0); // listener removed on resolve
+	});
+
+	it("gives up (connected=false) after maxMs without hanging", async () => {
+		const fake = fakeRepo({});
+		const start = Date.now();
+		const conn = await waitForConnection(fake.repo, "subduction", { maxMs: 120 });
+		expect(conn.connected).toBe(false);
+		expect(conn.serverPeerId).toBeUndefined();
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		expect(fake.listenerCount()).toBe(0);
+	});
+});


### PR DESCRIPTION
A couple fixes:

* Bump to latest subducted am-repo
* Don't redundantly resync docs four times on some code paths
* Fix benign warning output
* Properly format true error output
* Only print `SYNCED` when it actually synced (currently also says that if there was an error)
* Haven't been able to reproduce it today, but in theory remove 60s+ hang that happened sometimes

# Formatting

## Before :disappointed: 

```console
$ pushwork init
┌   pushwork init 
│
[lifecycle] 2026-07-03T00:17:09.949Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
◇  Connecting to sync server (35ms)
│
◇  Reading working tree (51ms)
│
◐  Encoding 282 files[lifecycle] 2026-07-03T00:17:10.233Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.241Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.236Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.246Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.258Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
◓  Encoding 282 files[lifecycle] 2026-07-03T00:17:10.265Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.267Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.269Z subduction ws connecting to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:10.331Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files..[lifecycle] 2026-07-03T00:17:11.764Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files...[lifecycle] 2026-07-03T00:17:12.073Z subduction ws connected to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:12.102Z subduction ws connected to wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:12.108Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◓  Encoding 282 files...[lifecycle] 2026-07-03T00:17:12.211Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◑  Encoding 282 files...[lifecycle] 2026-07-03T00:17:12.350Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◐  Encoding 282 files.[lifecycle] 2026-07-03T00:17:13.586Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◐  Encoding 282 files.[lifecycle] 2026-07-03T00:17:13.991Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◑  Encoding 282 files.[lifecycle] 2026-07-03T00:17:14.160Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files.[lifecycle] 2026-07-03T00:17:14.249Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◐  Encoding 282 files..[lifecycle] 2026-07-03T00:17:14.263Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
[lifecycle] 2026-07-03T00:17:14.322Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files..[lifecycle] 2026-07-03T00:17:14.505Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◑  Encoding 282 files[lifecycle] 2026-07-03T00:17:15.775Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files.[lifecycle] 2026-07-03T00:17:16.810Z subduction ws connected to wss://subduction.sync.inkandswitch.com
◒  Encoding 282 files[lifecycle] 2026-07-03T00:17:18.443Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◇  Encoding 282 files (8.5s)
│
◒  Publishing to sync server..[lifecycle] 2026-07-03T00:17:20.221Z subduction ws disconnected from wss://subduction.sync.inkandswitch.com
◇  Publishing to sync server (1.70s)
│
│  Path     /home/expede/Documents/Soft/ts-odd
│  Files    282 tracked
│  Backend  subduction
│  Sync     wss://subduction.sync.inkandswitch.com
│
│   INITIALIZED  automerge:3XK8ADzh2q19qfJnMirTrd9ssfse
│
│   SYNCED 
│
│  root doc      automerge:3XK8ADzh2q19qfJnMirTrd9ssfse
│  sync server   f709c58c1951bb8375d99495b2b9404abb1b84677a8ba5d6789e126894414c19
│  connected in  364ms
│  root heads    2p9QSEwCypvau88sS9LgNJrigbqPSV6uni99M8fcYaE9n7iT9q
│  server heads  2p9QSEwCypvau88sS9LgNJrigbqPSV6uni99M8fcYaE9n7iT9q
│
└  Done
```

## After :rocket: 

```console
$ pushwork init
┌   pushwork init 
│
◇  Connecting to sync server (38ms)
│
◇  Reading working tree (32ms)
│
◇  Encoding 282 files (4.4s)
│
◇  Publishing 282 files to the sync server (1.64s)
│
│  Path     /home/expede/Documents/Soft/ts-odd
│  Files    282 tracked
│  Backend  subduction
│  Sync     wss://subduction.sync.inkandswitch.com
│
│   INITIALIZED  automerge:thJsi94eashA3iKr8HcV4qKonVW
│
│   SYNCED 
│
│  root doc      automerge:thJsi94eashA3iKr8HcV4qKonVW
│  sync server   f709c58c1951bb8375d99495b2b9404abb1b84677a8ba5d6789e126894414c19
│  root heads    4RFxmDKpRErtWVPmnKBcnNN29ZBUp4EaSSoX7X9KDDCYFjJhW
│  server heads  4RFxmDKpRErtWVPmnKBcnNN29ZBUp4EaSSoX7X9KDDCYFjJhW
│
└  Done
```