### PR TITLE
Findin' bugs / fixin' tests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,6 +84,26 @@ setAmrepoErrorSink((namespace, message, ...args) => {
 const collect = (value: string, prev: string[] | undefined) =>
 	(prev ?? []).concat(value);
 
+/**
+ * Delivery confirmation stalled after its built-in retries: interactively ask
+ * whether to keep waiting. Non-interactive (CI, pipes) defaults to no — the
+ * command finishes as PENDING and the docs ride the shutdown quiesce.
+ */
+const confirmStallPrompt = (unconfirmed: number, total: number) =>
+	out.confirm(
+		`${unconfirmed} of ${total} documents still unconfirmed by the sync server — keep waiting?`,
+		false,
+	);
+
+/** In-place spinner progress bar: `Confirming delivery ████░░░░ 123/250`. */
+const confirmProgressBar = (confirmed: number, total: number) => {
+	const width = 24;
+	const filled = total > 0 ? Math.round((confirmed / total) * width) : width;
+	out.progress(
+		`Confirming delivery ${"█".repeat(filled)}${"░".repeat(width - filled)} ${confirmed}/${total}`,
+	);
+};
+
 const backendOf = (opts: { sub?: boolean; legacy?: boolean }) =>
 	opts.legacy || opts.sub === false ? "legacy" : "subduction";
 
@@ -129,6 +149,7 @@ function reportSync(sync: SyncSnapshot | undefined): void {
 			`sync\t${sync.synced ? "synced" : sync.pending ? "pending" : sync.connected ? "behind" : "offline"}`,
 		);
 		out.log(`connect\t${sync.connectMs ?? ""}`);
+		if (sync.unconfirmed) out.log(`uploading\t${sync.unconfirmed}`);
 		out.log(`root\t${sync.url}\t${sync.localHeads.join(" ")}`);
 		out.log(`server\t${sync.serverPeerId ?? ""}\t${sync.serverHeads.join(" ")}`);
 		return;
@@ -147,6 +168,13 @@ function reportSync(sync: SyncSnapshot | undefined): void {
 		"sync server": sync.serverPeerId ?? "(not connected)",
 		"root heads": fmtHeads(sync.localHeads),
 		"server heads": fmtHeads(sync.serverHeads),
+		...(sync.unconfirmed
+			? {
+					uploading: `${sync.unconfirmed} document${
+						sync.unconfirmed === 1 ? "" : "s"
+					} still syncing — finishes in the background or on the next sync`,
+				}
+			: {}),
 	});
 }
 
@@ -239,7 +267,14 @@ program
 		out.intro("pushwork init");
 		out.task("Connecting to sync server");
 		const info = await init(
-			{ dir: root, backend, shape: opts.shape, artifactDirectories: opts.artifactDir },
+			{
+				dir: root,
+				backend,
+				shape: opts.shape,
+				artifactDirectories: opts.artifactDir,
+				onConfirmStalled: confirmStallPrompt,
+				onConfirmProgress: confirmProgressBar,
+			},
 			report,
 			warn,
 		);
@@ -367,7 +402,16 @@ program
 		dlog("sync cwd=%s opts=%o", process.cwd(), opts);
 		out.intro(opts.nuclear ? "pushwork sync --nuclear" : "pushwork sync");
 		out.task("Connecting to sync server");
-		const snapshot = await sync(process.cwd(), { nuclear: opts.nuclear }, report, warn);
+		const snapshot = await sync(
+			process.cwd(),
+			{
+				nuclear: opts.nuclear,
+				onConfirmStalled: confirmStallPrompt,
+				onConfirmProgress: confirmProgressBar,
+			},
+			report,
+			warn,
+		);
 		out.done(); // complete the final phase line before the summary
 		reportSync(snapshot);
 		out.outro(opts.nuclear ? "nuclear synced" : "synced");

--- a/src/output.ts
+++ b/src/output.ts
@@ -143,6 +143,18 @@ export class Output {
 		this.task(message);
 	}
 
+	/**
+	 * Update the live spinner's text in place — no new line per tick. The
+	 * latest text becomes the phase's completion line, so the final state
+	 * (e.g. a full progress bar) persists. Porcelain/plain/quiet: no-op; those
+	 * modes get one completion line per phase and shouldn't be tick-spammed.
+	 */
+	progress(message: string): void {
+		if (!this.spinner) return;
+		this.taskMessage = message;
+		this.spinner.message(message);
+	}
+
 	done(message?: string, showTime = true): void {
 		if (this.taskStart == null) return;
 		let text = message ?? this.taskMessage ?? "done";

--- a/src/pushwork.ts
+++ b/src/pushwork.ts
@@ -194,7 +194,12 @@ export async function init(
 
 		const title = path.basename(root) || undefined;
 		report(`Encoding ${fsFiles.size} ${fsFiles.size === 1 ? "file" : "files"}`);
-		const tree = await pushFiles(repo, fsFiles, undefined, isArtifactPath);
+		const { tree, changedUrls } = await pushFiles(
+			repo,
+			fsFiles,
+			undefined,
+			isArtifactPath,
+		);
 		const folderUrl = await shape.encode({
 			repo,
 			tree,
@@ -210,10 +215,14 @@ export async function init(
 				`Publishing ${fsFiles.size} ${fsFiles.size === 1 ? "file" : "files"} to the sync server`,
 			);
 			stampLastSyncAt(folderHandle);
+			// Confirm the leaf docs alongside the folder doc — a clone is only
+			// viable once the server holds both.
+			const leafConfirm = confirmDocs(repo, changedUrls, opts.backend, connWait);
 			sync = await waitForServerSync(repo, folderHandle, opts.backend, {
 				idleMs: 1500,
 				maxMs: 15000,
 			});
+			await leafConfirm;
 		}
 
 		await writeConfig(root, {
@@ -251,6 +260,10 @@ export async function clone(
 	const connWait = online ? waitForConnection(repo, opts.backend) : undefined;
 	try {
 		report("Fetching repository");
+		// Gate the initial find on the server handshake: with an empty local
+		// store and a socket still connecting, `find` can resolve "unavailable"
+		// before the server was ever asked.
+		if (connWait) await connWait;
 		let folderHandle = await repo.find<unknown>(opts.url as AutomergeUrl);
 		if (online) {
 			await waitForSync(folderHandle, { idleMs: 1500, maxMs: 15000 });
@@ -479,8 +492,13 @@ export async function yoink(
 	const root = path.resolve(cwd);
 	dlog("yoink url=%s dest=%s root=%s", docUrl, destPath ?? "(from doc)", root);
 
-	const { repo, cleanup } = await openDetachedRepo(root, backend);
+	const { repo, backend: resolvedBackend, cleanup } = await openDetachedRepo(
+		root,
+		backend,
+	);
 	try {
+		// Don't race the socket: find + settle are useless before the handshake.
+		await waitForConnection(repo, resolvedBackend);
 		const handle = await repo.find<UnixFileEntry>(docUrl);
 		await waitForSync(handle as DocHandle<unknown>, { idleMs: 1500, maxMs: 15000 });
 		const { bytes, entry } = readFileEntry(handle as DocHandle<unknown>);
@@ -533,6 +551,9 @@ export async function yeet(
 		backend,
 	);
 	try {
+		// Don't race the socket: the catch-up and confirmation below are
+		// meaningless before the handshake completes.
+		await waitForConnection(repo, resolvedBackend);
 		const handle = await repo.find<UnixFileEntry>(stripHeads(docUrl));
 		// Catch up to the server before overwriting, then confirm our write made
 		// it back to the server.
@@ -705,7 +726,7 @@ async function commitWorkdir(
 		const fsFiles = await walkDir(root, ig);
 
 		report(online ? "Committing local changes" : "Writing documents");
-		const newTree = await pushFiles(
+		const { tree: newTree, changedUrls } = await pushFiles(
 			repo,
 			fsFiles,
 			previousFiles,
@@ -750,10 +771,14 @@ async function commitWorkdir(
 			// "we reconciled with the server at this time" — then confirm the
 			// server has caught up to the stamped (and any refreshed) state.
 			stampLastSyncAt(folderHandle);
+			// Confirm changed leaf docs alongside the folder doc — peers resolve
+			// the folder's entries against the server, so both must land.
+			const leafConfirm = confirmDocs(repo, changedUrls, config.backend, connWait);
 			sync = await waitForServerSync(repo, folderHandle, config.backend, {
 				idleMs: 1500,
 				maxMs: refreshed ? 10000 : hasArtifacts ? 5000 : 15000,
 			});
+			await leafConfirm;
 		}
 
 		if (online) report("Writing changes");
@@ -1072,8 +1097,9 @@ async function pushFiles(
 	fsFiles: Map<string, Uint8Array>,
 	previous: Map<string, { url: AutomergeUrl; bytes: Uint8Array }> | undefined,
 	isArtifactPath: IsArtifact,
-): Promise<VfsNode> {
+): Promise<{ tree: VfsNode; changedUrls: AutomergeUrl[] }> {
 	const root = newDir();
+	const changedUrls: AutomergeUrl[] = [];
 	let created = 0;
 	let updated = 0;
 	let unchanged = 0;
@@ -1098,12 +1124,14 @@ async function pushFiles(
 			const handle = await repo.find<UnixFileEntry>(refreshUrl);
 			applyFileEntry(handle, fresh);
 			baseUrl = refreshUrl;
+			changedUrls.push(refreshUrl);
 			updated++;
 			dlog("pushFiles updated %s url=%s artifact=%s bytes=%d", posixPath, baseUrl, isArtifact, bytes.length);
 		} else {
 			// New path: create a fresh file doc.
 			const handle = repo.create<UnixFileEntry>(fresh);
 			baseUrl = handle.url;
+			changedUrls.push(handle.url);
 			created++;
 			dlog("pushFiles created %s url=%s artifact=%s bytes=%d", posixPath, baseUrl, isArtifact, bytes.length);
 		}
@@ -1114,7 +1142,48 @@ async function pushFiles(
 		setFileAt(root, segments, finalUrl);
 	}
 	dlog("pushFiles done: %d created, %d updated, %d unchanged", created, updated, unchanged);
-	return root;
+	return { tree: root, changedUrls };
+}
+
+// Bounded fan-out for post-commit push-confirmation of changed file docs.
+const CONFIRM_CONCURRENCY = 16;
+
+/**
+ * Push-confirm each changed file doc with the server, not just the folder
+ * doc. Without this, freshly created/updated leaf docs ride solely on the
+ * shutdown quiesce; on a slow link the process can exit before they land,
+ * leaving the folder entry pointing at a doc the server never received
+ * (the clone-unavailable / propagation flake family). Callers pass only the
+ * docs changed this run — the server may not have advertised heads for
+ * untouched docs, and waiting on those would burn the whole budget.
+ */
+async function confirmDocs(
+	repo: Repo,
+	urls: readonly AutomergeUrl[],
+	backend: Backend,
+	connWait: Promise<Connection> | undefined,
+	{ maxMs = 15000 }: { maxMs?: number } = {},
+): Promise<void> {
+	if (urls.length === 0) return;
+	// No confirmation is possible without a server; don't burn the budget
+	// (e.g. init against an unreachable server must still finish promptly).
+	if (connWait && !(await connWait).connected) return;
+	// One global deadline across all batches — a many-file commit on a dead-ish
+	// link degrades to a single bounded wait, not maxMs per batch.
+	const deadline = Date.now() + maxMs;
+	for (let i = 0; i < urls.length; i += CONFIRM_CONCURRENCY) {
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) return;
+		await Promise.all(
+			urls.slice(i, i + CONFIRM_CONCURRENCY).map(async (url) => {
+				const handle = await repo.find<unknown>(stripHeads(url));
+				await waitForServerSync(repo, handle, backend, {
+					idleMs: 1500,
+					maxMs: remaining,
+				});
+			}),
+		);
+	}
 }
 
 /**

--- a/src/pushwork.ts
+++ b/src/pushwork.ts
@@ -22,6 +22,8 @@ import { ATTRIBUTES_FILE, readAttributes } from "./attributes.js";
 import { byteEq, walkDir, writeFileAtomic } from "./fs-tree.js";
 import { log } from "./log.js";
 import {
+	confirmDelivery,
+	findBounded,
 	openRepo,
 	safeShutdown,
 	waitForConnection,
@@ -118,6 +120,14 @@ export type InitOpts = {
 	shape: string;
 	artifactDirectories?: readonly string[];
 	online?: boolean; // default: true
+	/**
+	 * Delivery-confirmation stalled with docs outstanding (after the built-in
+	 * retries): resolve true to keep waiting, false to finish as PENDING.
+	 * Omitted ⇒ finish as PENDING (non-interactive behavior).
+	 */
+	onConfirmStalled?: (unconfirmed: number, total: number) => Promise<boolean>;
+	/** Confirmation progress ticks (for progress bars); default: phase report. */
+	onConfirmProgress?: (confirmed: number, total: number) => void;
 };
 
 export type CloneOpts = {
@@ -225,12 +235,19 @@ export async function init(
 				[...changedUrls, ...folderDocUrls.filter((u) => u !== folderUrl)],
 				opts.backend,
 				connWait,
+				{
+					onProgress:
+						opts.onConfirmProgress ??
+						((confirmed, total) =>
+							report(`Confirming delivery (${confirmed}/${total})`)),
+					onStalled: opts.onConfirmStalled,
+				},
 			);
 			sync = await waitForServerSync(repo, folderHandle, opts.backend, {
 				idleMs: 1500,
 				maxMs: 15000,
 			});
-			await leafConfirm;
+			sync = degradeUnconfirmed(sync, await leafConfirm);
 		}
 
 		await writeConfig(root, {
@@ -272,7 +289,10 @@ export async function clone(
 		// store and a socket still connecting, `find` can resolve "unavailable"
 		// before the server was ever asked.
 		if (connWait) await connWait;
-		let folderHandle = await repo.find<unknown>(opts.url as AutomergeUrl);
+		let folderHandle: DocHandle<unknown> = await findBounded<unknown>(
+			repo,
+			opts.url as AutomergeUrl,
+		);
 		if (online) {
 			await waitForSync(folderHandle, { idleMs: 1500, maxMs: 15000 });
 		}
@@ -293,7 +313,7 @@ export async function clone(
 				branches,
 			});
 			dlog("clone branches doc → chose %s", chosenUrl);
-			folderHandle = await repo.find<unknown>(chosenUrl);
+			folderHandle = await findBounded<unknown>(repo, chosenUrl);
 			if (online) {
 				await waitForSync(folderHandle, { idleMs: 1500, maxMs: 15000 });
 			}
@@ -507,7 +527,7 @@ export async function yoink(
 	try {
 		// Don't race the socket: find + settle are useless before the handshake.
 		await waitForConnection(repo, resolvedBackend);
-		const handle = await repo.find<UnixFileEntry>(docUrl);
+		const handle = await findBounded<UnixFileEntry>(repo, docUrl as AutomergeUrl);
 		await waitForSync(handle as DocHandle<unknown>, { idleMs: 1500, maxMs: 15000 });
 		const { bytes, entry } = readFileEntry(handle as DocHandle<unknown>);
 
@@ -562,7 +582,10 @@ export async function yeet(
 		// Don't race the socket: the catch-up and confirmation below are
 		// meaningless before the handshake completes.
 		await waitForConnection(repo, resolvedBackend);
-		const handle = await repo.find<UnixFileEntry>(stripHeads(docUrl));
+		const handle = await findBounded<UnixFileEntry>(
+			repo,
+			stripHeads(docUrl as AutomergeUrl),
+		);
 		// Catch up to the server before overwriting, then confirm our write made
 		// it back to the server.
 		await waitForServerSync(repo, handle as DocHandle<unknown>, resolvedBackend, {
@@ -583,7 +606,11 @@ export async function yeet(
 
 export async function sync(
 	cwd: string,
-	opts: { nuclear?: boolean } = {},
+	opts: {
+		nuclear?: boolean;
+		onConfirmStalled?: (unconfirmed: number, total: number) => Promise<boolean>;
+		onConfirmProgress?: (confirmed: number, total: number) => void;
+	} = {},
 	report: Reporter = noReport,
 	warn: Warn = noWarn,
 ): Promise<SyncSnapshot | undefined> {
@@ -593,7 +620,16 @@ export async function sync(
 		report("Publishing to sync server");
 		return await publishCurrentTree(cwd);
 	}
-	return await commitWorkdir(cwd, { online: true }, report, warn);
+	return await commitWorkdir(
+		cwd,
+		{
+			online: true,
+			onConfirmStalled: opts.onConfirmStalled,
+			onConfirmProgress: opts.onConfirmProgress,
+		},
+		report,
+		warn,
+	);
 }
 
 /**
@@ -705,7 +741,15 @@ export async function save(
 
 async function commitWorkdir(
 	cwd: string,
-	{ online }: { online: boolean },
+	{
+		online,
+		onConfirmStalled,
+		onConfirmProgress,
+	}: {
+		online: boolean;
+		onConfirmStalled?: (unconfirmed: number, total: number) => Promise<boolean>;
+		onConfirmProgress?: (confirmed: number, total: number) => void;
+	},
 	report: Reporter = noReport,
 	warn: Warn = noWarn,
 ): Promise<SyncSnapshot | undefined> {
@@ -791,12 +835,19 @@ async function commitWorkdir(
 				],
 				config.backend,
 				connWait,
+				{
+					onProgress:
+						onConfirmProgress ??
+						((confirmed, total) =>
+							report(`Confirming delivery (${confirmed}/${total})`)),
+					onStalled: onConfirmStalled,
+				},
 			);
 			sync = await waitForServerSync(repo, folderHandle, config.backend, {
 				idleMs: 1500,
 				maxMs: refreshed ? 10000 : hasArtifacts ? 5000 : 15000,
 			});
-			await leafConfirm;
+			sync = degradeUnconfirmed(sync, await leafConfirm);
 		}
 
 		if (online) report("Writing changes");
@@ -1163,8 +1214,23 @@ async function pushFiles(
 	return { tree: root, changedUrls };
 }
 
-// Bounded fan-out for post-commit push-confirmation of changed file docs.
-const CONFIRM_CONCURRENCY = 16;
+
+
+/**
+ * Fold the leaf/folder confirmation result into the root verdict: a SYNCED
+ * root with unconfirmed children is not synced — report PENDING (with the
+ * in-flight count carried on the snapshot for display) instead of silently
+ * declaring victory with docs peers would still see as "unavailable".
+ */
+function degradeUnconfirmed(
+	sync: SyncSnapshot | undefined,
+	{ unconfirmed }: { unconfirmed: number },
+): SyncSnapshot | undefined {
+	if (unconfirmed === 0 || !sync) return sync;
+	// Disconnected: OFFLINE already tells the story — don't relabel it PENDING.
+	if (!sync.connected) return sync;
+	return { ...sync, synced: false, pending: true, unconfirmed };
+}
 
 /**
  * Push-confirm each changed file doc with the server, not just the folder
@@ -1180,29 +1246,25 @@ async function confirmDocs(
 	urls: readonly AutomergeUrl[],
 	backend: Backend,
 	connWait: Promise<Connection> | undefined,
-	{ maxMs = 15000 }: { maxMs?: number } = {},
-): Promise<void> {
+	{
+		onProgress,
+		onStalled,
+	}: {
+		onProgress?: (confirmed: number, total: number) => void;
+		onStalled?: (unconfirmed: number, total: number) => Promise<boolean>;
+	} = {},
+): Promise<{ unconfirmed: number }> {
 	const unique = [...new Set(urls)];
-	if (unique.length === 0) return;
-	// No confirmation is possible without a server; don't burn the budget
+	if (unique.length === 0) return { unconfirmed: 0 };
+	// No confirmation is possible without a server; don't burn any budget
 	// (e.g. init against an unreachable server must still finish promptly).
-	if (connWait && !(await connWait).connected) return;
-	// One global deadline across all batches — a many-file commit on a dead-ish
-	// link degrades to a single bounded wait, not maxMs per batch.
-	const deadline = Date.now() + maxMs;
-	for (let i = 0; i < unique.length; i += CONFIRM_CONCURRENCY) {
-		const remaining = deadline - Date.now();
-		if (remaining <= 0) return;
-		await Promise.all(
-			unique.slice(i, i + CONFIRM_CONCURRENCY).map(async (url) => {
-				const handle = await repo.find<unknown>(stripHeads(url));
-				await waitForServerSync(repo, handle, backend, {
-					idleMs: 1500,
-					maxMs: remaining,
-				});
-			}),
-		);
+	if (connWait && !(await connWait).connected) {
+		return { unconfirmed: unique.length };
 	}
+	const handles = await Promise.all(
+		unique.map((url) => repo.find<unknown>(stripHeads(url))),
+	);
+	return confirmDelivery(repo, handles, backend, { onProgress, onStalled });
 }
 
 /**
@@ -1250,7 +1312,8 @@ async function readFileBytes(
 ): Promise<Map<string, { url: AutomergeUrl; bytes: Uint8Array }>> {
 	const out = new Map<string, { url: AutomergeUrl; bytes: Uint8Array }>();
 	for (const [posixPath, fileUrl] of flattenLeaves(tree)) {
-		const handle = await repo.find<UnixFileEntry>(fileUrl);
+		// Possibly remote (a peer's new doc arriving via sync): bound the fetch.
+		const handle = await findBounded<UnixFileEntry>(repo, fileUrl);
 		out.set(posixPath, {
 			url: fileUrl,
 			bytes: contentToBytes(handle.doc().content),
@@ -1274,7 +1337,7 @@ async function materializeTree(
 	const desired = new Map<string, Uint8Array>();
 	await Promise.all(
 		[...leaves].map(async ([posixPath, fileUrl]) => {
-			const handle = await repo.find<UnixFileEntry>(fileUrl);
+			const handle = await findBounded<UnixFileEntry>(repo, fileUrl);
 			desired.set(posixPath, contentToBytes(handle.doc().content));
 		}),
 	);

--- a/src/pushwork.ts
+++ b/src/pushwork.ts
@@ -200,11 +200,13 @@ export async function init(
 			undefined,
 			isArtifactPath,
 		);
+		const folderDocUrls: AutomergeUrl[] = [];
 		const folderUrl = await shape.encode({
 			repo,
 			tree,
 			title,
 			isArtifactDir: isArtifactPath,
+			onDocChanged: (u) => folderDocUrls.push(u),
 		});
 		dlog("init encoded folder=%s title=%s", folderUrl, title);
 		const folderHandle = await repo.find<unknown>(folderUrl);
@@ -215,9 +217,15 @@ export async function init(
 				`Publishing ${fsFiles.size} ${fsFiles.size === 1 ? "file" : "files"} to the sync server`,
 			);
 			stampLastSyncAt(folderHandle);
-			// Confirm the leaf docs alongside the folder doc — a clone is only
-			// viable once the server holds both.
-			const leafConfirm = confirmDocs(repo, changedUrls, opts.backend, connWait);
+			// Confirm leaf AND intermediate folder docs alongside the root doc — a
+			// clone resolves the whole tree against the server, so every doc must
+			// land, not just the root (nested-tree clones flaked on exactly this).
+			const leafConfirm = confirmDocs(
+				repo,
+				[...changedUrls, ...folderDocUrls.filter((u) => u !== folderUrl)],
+				opts.backend,
+				connWait,
+			);
 			sync = await waitForServerSync(repo, folderHandle, opts.backend, {
 				idleMs: 1500,
 				maxMs: 15000,
@@ -734,12 +742,14 @@ async function commitWorkdir(
 		);
 		const changed = !sameTree(previousTree, newTree);
 		dlog("commit tree changed: %s", changed);
+		const folderDocUrls: AutomergeUrl[] = [];
 		if (changed) {
 			await shape.encode({
 				repo,
 				tree: newTree,
 				previousRoot: folderHandle,
 				isArtifactDir: isArtifactPath,
+				onDocChanged: (u) => folderDocUrls.push(u),
 			});
 		}
 
@@ -771,9 +781,17 @@ async function commitWorkdir(
 			// "we reconciled with the server at this time" — then confirm the
 			// server has caught up to the stamped (and any refreshed) state.
 			stampLastSyncAt(folderHandle);
-			// Confirm changed leaf docs alongside the folder doc — peers resolve
-			// the folder's entries against the server, so both must land.
-			const leafConfirm = confirmDocs(repo, changedUrls, config.backend, connWait);
+			// Confirm changed leaf AND intermediate folder docs alongside the root
+			// doc — peers resolve the tree against the server, so all must land.
+			const leafConfirm = confirmDocs(
+				repo,
+				[
+					...changedUrls,
+					...folderDocUrls.filter((u) => u !== config.rootUrl),
+				],
+				config.backend,
+				connWait,
+			);
 			sync = await waitForServerSync(repo, folderHandle, config.backend, {
 				idleMs: 1500,
 				maxMs: refreshed ? 10000 : hasArtifacts ? 5000 : 15000,
@@ -1164,18 +1182,19 @@ async function confirmDocs(
 	connWait: Promise<Connection> | undefined,
 	{ maxMs = 15000 }: { maxMs?: number } = {},
 ): Promise<void> {
-	if (urls.length === 0) return;
+	const unique = [...new Set(urls)];
+	if (unique.length === 0) return;
 	// No confirmation is possible without a server; don't burn the budget
 	// (e.g. init against an unreachable server must still finish promptly).
 	if (connWait && !(await connWait).connected) return;
 	// One global deadline across all batches — a many-file commit on a dead-ish
 	// link degrades to a single bounded wait, not maxMs per batch.
 	const deadline = Date.now() + maxMs;
-	for (let i = 0; i < urls.length; i += CONFIRM_CONCURRENCY) {
+	for (let i = 0; i < unique.length; i += CONFIRM_CONCURRENCY) {
 		const remaining = deadline - Date.now();
 		if (remaining <= 0) return;
 		await Promise.all(
-			urls.slice(i, i + CONFIRM_CONCURRENCY).map(async (url) => {
+			unique.slice(i, i + CONFIRM_CONCURRENCY).map(async (url) => {
 				const handle = await repo.find<unknown>(stripHeads(url));
 				await waitForServerSync(repo, handle, backend, {
 					idleMs: 1500,

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -290,6 +290,26 @@ async function connectedServerPeer(repo: Repo): Promise<string | undefined> {
 	}
 }
 
+/**
+ * Resolve the server peer and the key under which `DocHandle.getSyncInfo`
+ * tracks its advertised heads. Subduction keys sync info by the peer id
+ * itself; classic sync keys it by the peer's announced storageId — `syncKey`
+ * is undefined until the relevant handshake has completed (and stays
+ * undefined for a legacy relay that never announces a storageId).
+ */
+async function serverSyncTarget(
+	repo: Repo,
+	backend: Backend,
+): Promise<{ peerId?: string; syncKey?: string }> {
+	if (backend === "subduction") {
+		const peerId = await connectedServerPeer(repo);
+		return { peerId, syncKey: peerId };
+	}
+	const peerId = repo.peers[0];
+	if (peerId === undefined) return {};
+	return { peerId, syncKey: repo.getStorageIdOfPeer(peerId) };
+}
+
 export type Connection = {
 	connected: boolean;
 	/** ms from this call until the connection was established (0 if already up). */
@@ -310,7 +330,37 @@ export async function waitForConnection(
 	{ maxMs = 15000 }: { maxMs?: number } = {},
 ): Promise<Connection> {
 	const start = Date.now();
-	if (backend !== "subduction") return { connected: false, connectMs: 0 };
+	if (backend !== "subduction") {
+		// Legacy: the WebSocketClientAdapter connects asynchronously and there is
+		// no subduction handshake to observe — wait for the classic "peer" event
+		// instead. Without this gate, a command's local settle (~1.5s) can finish
+		// before the socket even opens, and the repo shuts down having sent
+		// nothing (the legacy-flake family: clone-after-init unavailable, yeet
+		// never delivered).
+		const firstPeer = () => repo.peers[0] as string | undefined;
+		if (firstPeer() !== undefined) {
+			return { connected: true, connectMs: 0, serverPeerId: firstPeer() };
+		}
+		const connected = await new Promise<boolean>((resolve) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const net = repo.networkSubsystem;
+			const onPeer = () => {
+				if (timer) clearTimeout(timer);
+				net.off("peer", onPeer);
+				resolve(true);
+			};
+			net.on("peer", onPeer);
+			timer = setTimeout(() => {
+				net.off("peer", onPeer);
+				resolve(firstPeer() !== undefined);
+			}, maxMs);
+		});
+		return {
+			connected,
+			connectMs: Date.now() - start,
+			serverPeerId: connected ? firstPeer() : undefined,
+		};
+	}
 	if (repo.isSubductionConnected()) {
 		return { connected: true, connectMs: 0, serverPeerId: await connectedServerPeer(repo) };
 	}
@@ -433,8 +483,11 @@ export function syncVerdict(args: {
  * direction; we additionally gate on a brief local-heads settle so our own edit
  * has flushed before we trust the result.
  *
- * On the legacy backend there is no Subduction peer to hear from, so this falls
- * back to {@link waitForSync} and reports connected=false with empty serverHeads.
+ * The legacy backend speaks the classic sync protocol, but a relay that
+ * announces a storageId (the stock automerge sync server does) still yields
+ * per-doc sync info — so both backends get the same push-confirmed verdict.
+ * Only a relay without a storageId falls back to {@link waitForSync}'s
+ * local settle.
  */
 export async function waitForServerSync<T>(
 	repo: Repo,
@@ -448,31 +501,24 @@ export async function waitForServerSync<T>(
 	}: { idleMs?: number; maxMs?: number; pollMs?: number; resyncAfterMs?: number } = {},
 ): Promise<SyncSnapshot> {
 	const headsOf = () => [...(handle.heads() ?? [])] as string[];
-
-	// Legacy backend never speaks Subduction: there are no server heads to
-	// compare against, so settle locally and report what little we can.
-	if (backend !== "subduction") {
-		await waitForSync(handle, { idleMs, maxMs });
-		return {
-			url: handle.url,
-			synced: true,
-			pending: false,
-			connected: false,
-			localHeads: headsOf(),
-			serverHeads: [],
-		};
-	}
+	const isConnected = () =>
+		backend === "subduction"
+			? repo.isSubductionConnected()
+			: repo.peers.length > 0;
 
 	const documentId = handle.documentId;
 	dlog("waitForServerSync url=%s idleMs=%d maxMs=%d", handle.url, idleMs, maxMs);
 
 	// Wake the poll loop the instant the server advertises new heads for this doc
-	// (otherwise we just notice on the next poll tick).
+	// (otherwise we just notice on the next poll tick). Subduction advertises via
+	// the repo-level event; classic sync via the handle-level one.
 	let wake: (() => void) | null = null;
 	const onRemoteHeads = (p: { documentId: string }) => {
 		if (p.documentId === documentId) wake?.();
 	};
 	repo.on("subduction-remote-heads", onRemoteHeads);
+	const onHandleRemoteHeads = () => wake?.();
+	handle.on("remote-heads", onHandleRemoteHeads);
 
 	const start = Date.now();
 	let lastHeads = JSON.stringify(handle.heads());
@@ -489,12 +535,36 @@ export async function waitForServerSync<T>(
 			}
 			const localQuiet = now - lastHeadsChange >= idleMs;
 
-			const serverPeerId = await connectedServerPeer(repo);
+			const { peerId: serverPeerId, syncKey } = await serverSyncTarget(
+				repo,
+				backend,
+			);
+
+			// A legacy relay that never announces a storageId can't be
+			// push-confirmed at all — settle locally for the remaining budget
+			// (the pre-verdict legacy behavior).
+			if (backend !== "subduction" && serverPeerId && syncKey === undefined) {
+				dlog("waitForServerSync legacy peer has no storageId; settling url=%s", handle.url);
+				await waitForSync(handle, {
+					idleMs,
+					maxMs: Math.max(pollMs, maxMs - (now - start)),
+				});
+				return {
+					url: handle.url,
+					synced: true,
+					pending: false,
+					connected: true,
+					serverPeerId,
+					localHeads: headsOf(),
+					serverHeads: [],
+				};
+			}
+
 			let serverHeads: string[] = [];
 			let synced = false;
 			let pending = false;
-			if (serverPeerId) {
-				const info = handle.getSyncInfo(serverPeerId as never);
+			if (syncKey) {
+				const info = handle.getSyncInfo(syncKey as never);
 				if (info && info.lastHeads.length > 0) {
 					({ synced, pending } = syncVerdict({
 						localQuiet,
@@ -520,7 +590,7 @@ export async function waitForServerSync<T>(
 					url: handle.url,
 					synced,
 					pending: synced ? false : pending,
-					connected: repo.isSubductionConnected(),
+					connected: isConnected(),
 					serverPeerId,
 					localHeads: headsOf(),
 					serverHeads,
@@ -530,7 +600,12 @@ export async function waitForServerSync<T>(
 			// Behind for a while and the scheduler isn't catching us up — re-arm a
 			// single fresh sync round (the technique's stuck-doc nudge, without the
 			// full per-doc exponential backoff a long-lived client would keep).
-			if (!resynced && serverPeerId && now - start >= resyncAfterMs) {
+			if (
+				backend === "subduction" &&
+				!resynced &&
+				serverPeerId &&
+				now - start >= resyncAfterMs
+			) {
 				resynced = true; // don't reconsider within this call regardless
 				if (claimResync(repo, documentId)) {
 					dlog("waitForServerSync nudging resync url=%s", handle.url);
@@ -551,6 +626,7 @@ export async function waitForServerSync<T>(
 		}
 	} finally {
 		repo.off("subduction-remote-heads", onRemoteHeads);
+		handle.off("remote-heads", onHandleRemoteHeads);
 	}
 }
 

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,4 +1,5 @@
 import {
+	parseAutomergeUrl,
 	Repo,
 	WorkerWebSocketEndpoint,
 	initSubduction,
@@ -242,6 +243,41 @@ const errMessage = (err: unknown): string =>
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * `repo.find` with a deadline and one retry — the only unbounded await in a
+ * pushwork command is a doc fetch, and a transport that wedges without
+ * closing (frames stop, socket stays "open") leaves it pending forever: the
+ * doc never turns ready, and "unavailable" needs a peer to actually answer.
+ * The retry re-issues the request after evicting the stuck load, which also
+ * recovers the case where a reconnect dropped the original request.
+ */
+export async function findBounded<T>(
+	repo: Repo,
+	url: AutomergeUrl,
+	{ maxMs = 30000, retries = 1 }: { maxMs?: number; retries?: number } = {},
+): Promise<DocHandle<T>> {
+	for (let attempt = 0; ; attempt++) {
+		const ctl = new AbortController();
+		const timer = setTimeout(
+			() => ctl.abort(new Error(`fetching ${url} timed out after ${maxMs}ms`)),
+			maxMs,
+		);
+		try {
+			return await repo.find<T>(url, { signal: ctl.signal });
+		} catch (err) {
+			if (!ctl.signal.aborted || attempt >= retries) throw err;
+			dlog("findBounded: %s timed out; evicting and retrying", url);
+			try {
+				await repo.removeFromCache(parseAutomergeUrl(url).documentId);
+			} catch {
+				// eviction is best-effort; the retry may still hit the stuck load
+			}
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+}
+
+/**
  * Where a document stands relative to the Subduction sync server. Returned by
  * {@link waitForServerSync}; the CLI renders the two head sets so you can see at
  * a glance that your repo and the server agree.
@@ -267,6 +303,12 @@ export type SyncSnapshot = {
 	connected: boolean;
 	/** The sync server's peer id (its verifying key), once the handshake is done. */
 	serverPeerId?: string;
+	/**
+	 * Docs changed this run whose delivery the server hadn't confirmed before
+	 * the deadline (set by the CLI's confirm pass, not by waitForServerSync).
+	 * They finish uploading during the shutdown quiesce or on the next sync.
+	 */
+	unconfirmed?: number;
 	/** Our current Automerge heads for the doc. */
 	localHeads: string[];
 	/** The heads the server last advertised for the doc (Subduction sedimentree heads). */
@@ -627,6 +669,157 @@ export async function waitForServerSync<T>(
 	} finally {
 		repo.off("subduction-remote-heads", onRemoteHeads);
 		handle.off("remote-heads", onHandleRemoteHeads);
+	}
+}
+
+/**
+ * Drain-style delivery confirmation for a set of docs written earlier in this
+ * command: one repo-level listener + one loop, instead of a poll loop per doc
+ * (which convoys on the slowest doc in each batch). A doc counts as confirmed
+ * when the server's advertised heads cover its Automerge frontier — the same
+ * push-confirmation rule as {@link waitForServerSync}, minus the local-settle
+ * gate (nothing local is racing; the writes happened before this call).
+ *
+ * The server advertises heads on its own sync schedule, not as a per-doc
+ * receipt, so stragglers get a collective `resyncSubduction` nudge after
+ * `nudgeAfterMs`, and again on every stall (no confirmation for `stallMs`)
+ * up to `retries` times. When retries are exhausted, `onStalled` is consulted:
+ * resolve true to keep waiting (retries reset), false to give up and report
+ * the remainder — the CLI wires this to an interactive prompt, so a user can
+ * choose to keep waiting out a slow server or bail to PENDING. A legacy relay
+ * without a storageId can't confirm anything; delivery is entrusted to the
+ * shutdown quiesce as before.
+ */
+export async function confirmDelivery(
+	repo: Repo,
+	handles: readonly DocHandle<unknown>[],
+	backend: Backend,
+	{
+		stallMs = 10000,
+		nudgeAfterMs = 3000,
+		pollMs = 500,
+		retries = 2,
+		onProgress,
+		onStalled,
+	}: {
+		stallMs?: number;
+		nudgeAfterMs?: number;
+		pollMs?: number;
+		/** Extra nudge rounds after a stall before consulting `onStalled`. */
+		retries?: number;
+		onProgress?: (confirmed: number, total: number) => void;
+		/** Called when retries are exhausted; true = keep waiting, false = bail. */
+		onStalled?: (unconfirmed: number, total: number) => Promise<boolean>;
+	} = {},
+): Promise<{ unconfirmed: number }> {
+	const pending = new Map<string, DocHandle<unknown>>();
+	for (const h of handles) pending.set(h.documentId, h);
+	const total = pending.size;
+	if (total === 0) return { unconfirmed: 0 };
+
+	const isConfirmed = (h: DocHandle<unknown>, syncKey: string): boolean => {
+		const info = h.getSyncInfo(syncKey as never);
+		if (!info || info.lastHeads.length === 0) return false;
+		const advertised = new Set<string>(info.lastHeads);
+		const frontier = [...(h.heads() ?? [])] as string[];
+		return frontier.length > 0 && frontier.every((x) => advertised.has(x));
+	};
+
+	// One wake channel for all docs: repo-level for subduction, handle-level
+	// for classic sync.
+	let wake: (() => void) | null = null;
+	const onRepoRemoteHeads = (p: { documentId: string }) => {
+		if (pending.has(p.documentId)) wake?.();
+	};
+	repo.on("subduction-remote-heads", onRepoRemoteHeads);
+	const handleListeners: Array<[DocHandle<unknown>, () => void]> = [];
+	for (const h of pending.values()) {
+		const fn = () => wake?.();
+		h.on("remote-heads", fn);
+		handleListeners.push([h, fn]);
+	}
+
+	const nudgePending = (viaClaim: boolean) => {
+		for (const h of pending.values()) {
+			if (viaClaim && !claimResync(repo, h.documentId)) continue;
+			try {
+				repo.resyncSubduction(h.documentId);
+			} catch {
+				// no Subduction source / doc not attached
+			}
+		}
+	};
+
+	const start = Date.now();
+	let lastCount = total;
+	let lastProgress = start;
+	let nudged = false;
+	let retriesLeft = retries;
+	try {
+		for (;;) {
+			const { peerId, syncKey } = await serverSyncTarget(repo, backend);
+			if (syncKey) {
+				for (const [id, h] of pending) {
+					if (isConfirmed(h, syncKey)) pending.delete(id);
+				}
+			} else if (backend !== "subduction" && peerId) {
+				// Relay never announces a storageId: unconfirmable by design;
+				// trust the settle + shutdown quiesce (pre-verdict legacy behavior).
+				dlog("confirmDelivery: legacy relay has no storageId; trusting quiesce");
+				return { unconfirmed: 0 };
+			}
+
+			const now = Date.now();
+			if (pending.size < lastCount) {
+				lastCount = pending.size;
+				lastProgress = now;
+				onProgress?.(total - pending.size, total);
+			}
+			if (pending.size === 0) return { unconfirmed: 0 };
+
+			// The server stores long before it advertises; prod it once for the
+			// stragglers instead of waiting out its gossip schedule.
+			if (backend === "subduction" && !nudged && now - start >= nudgeAfterMs) {
+				nudged = true;
+				nudgePending(true);
+				dlog("confirmDelivery: nudged %d stragglers", pending.size);
+			}
+
+			if (now - lastProgress >= stallMs) {
+				if (retriesLeft > 0) {
+					retriesLeft--;
+					lastProgress = now;
+					if (backend === "subduction") nudgePending(false);
+					dlog(
+						"confirmDelivery: stall retry (%d left) with %d/%d unconfirmed",
+						retriesLeft,
+						pending.size,
+						total,
+					);
+					continue;
+				}
+				if (onStalled && (await onStalled(pending.size, total))) {
+					retriesLeft = retries;
+					lastProgress = Date.now();
+					if (backend === "subduction") nudgePending(false);
+					continue;
+				}
+				dlog(
+					"confirmDelivery: stalled with %d/%d unconfirmed",
+					pending.size,
+					total,
+				);
+				return { unconfirmed: pending.size };
+			}
+
+			await sleepOrWake(pollMs, (fn) => {
+				wake = fn;
+			});
+			wake = null;
+		}
+	} finally {
+		repo.off("subduction-remote-heads", onRepoRemoteHeads);
+		for (const [h, fn] of handleListeners) h.off("remote-heads", fn);
 	}
 }
 

--- a/src/shapes/patchwork-folder.ts
+++ b/src/shapes/patchwork-folder.ts
@@ -59,7 +59,7 @@ const childPath = (dirPath: string, name: string) =>
 	dirPath ? `${dirPath}/${name}` : name;
 
 export const patchworkFolderShape: Shape = {
-	async encode({ repo, tree, previousRoot, isArtifactDir }) {
+	async encode({ repo, tree, previousRoot, isArtifactDir, onDocChanged }) {
 		if (tree.kind !== "dir") throw new Error("folder: root must be a dir");
 		const isArtifact: IsArtifactDir = isArtifactDir ?? (() => false);
 
@@ -68,11 +68,18 @@ export const patchworkFolderShape: Shape = {
 			const handle = previousRoot as DocHandle<FolderDoc>;
 			// Root path is "" — never an artifact dir — so the returned flag is
 			// ignored; callers track the repo by this bare URL.
-			await syncFolder(repo, handle, tree, "", isArtifact);
+			await syncFolder(repo, handle, tree, "", isArtifact, onDocChanged);
 			return handle.url;
 		}
 		dlog("encode creating new root");
-		const { handle } = await createFolder(repo, tree, "pushwork", "", isArtifact);
+		const { handle } = await createFolder(
+			repo,
+			tree,
+			"pushwork",
+			"",
+			isArtifact,
+			onDocChanged,
+		);
 		dlog("encode new root=%s", handle.url);
 		return handle.url;
 	},

--- a/src/shapes/patchwork-folder.ts
+++ b/src/shapes/patchwork-folder.ts
@@ -6,6 +6,7 @@ import {
 	type Repo,
 } from "@automerge/automerge-repo";
 import { log } from "../log.js";
+import { findBounded } from "../repo.js";
 import { pinUrl, stripHeads } from "./file.js";
 import { newDir, type Shape, type VfsNode } from "./types.js";
 
@@ -215,7 +216,9 @@ async function readFolder(
 		if (!link?.name) continue;
 		if (!isValidAutomergeUrl(link.url)) continue;
 		if (link.type === "folder") {
-			const sub = await repo.find<FolderDoc>(link.url);
+			// Possibly remote (clone / sync pull): bound the fetch so a wedged
+			// transport can't hang the whole command.
+			const sub = await findBounded<FolderDoc>(repo, link.url);
 			if (isFolderDoc(sub.doc())) {
 				const subTree = await readFolder(repo, sub);
 				if (tree.kind === "dir") tree.entries.set(link.name, subTree);

--- a/src/shapes/patchwork-folder.ts
+++ b/src/shapes/patchwork-folder.ts
@@ -100,6 +100,7 @@ async function createFolder(
 	title: string,
 	dirPath: string,
 	isArtifact: IsArtifactDir,
+	onDocChanged?: (url: AutomergeUrl) => void,
 ): Promise<{ handle: DocHandle<FolderDoc>; frozen: boolean }> {
 	if (tree.kind !== "dir") throw new Error("createFolder: not a dir");
 	const links: DocLink[] = [];
@@ -113,6 +114,7 @@ async function createFolder(
 				name,
 				childPath(dirPath, name),
 				isArtifact,
+				onDocChanged,
 			);
 			links.push({
 				name,
@@ -126,6 +128,7 @@ async function createFolder(
 		title,
 		docs: links,
 	});
+	onDocChanged?.(handle.url);
 	dlog("createFolder title=%s docs=%d url=%s", title, links.length, handle.url);
 	return { handle, frozen: isArtifact(dirPath) };
 }
@@ -136,6 +139,7 @@ async function syncFolder(
 	tree: VfsNode,
 	dirPath: string,
 	isArtifact: IsArtifactDir,
+	onDocChanged?: (url: AutomergeUrl) => void,
 ): Promise<boolean> {
 	if (tree.kind !== "dir") throw new Error("syncFolder: not a dir");
 
@@ -166,6 +170,7 @@ async function syncFolder(
 					child,
 					childPath(dirPath, name),
 					isArtifact,
+					onDocChanged,
 				);
 				nextLinks.push({
 					name,
@@ -181,6 +186,7 @@ async function syncFolder(
 			name,
 			childPath(dirPath, name),
 			isArtifact,
+			onDocChanged,
 		);
 		nextLinks.push({
 			name,
@@ -194,6 +200,7 @@ async function syncFolder(
 		if (typeof d.title !== "string") d.title = "pushwork";
 		d.docs = nextLinks;
 	});
+	onDocChanged?.(handle.url);
 	return isArtifact(dirPath);
 }
 

--- a/src/shapes/types.ts
+++ b/src/shapes/types.ts
@@ -30,6 +30,13 @@ export interface Shape {
 		 * the whole subtree reads as frozen. Omitted ⇒ no folder is pinned.
 		 */
 		isArtifactDir?: (posixPath: string) => boolean;
+		/**
+		 * Invoked with the bare URL of every directory doc this encode created or
+		 * rewrote (root included). Callers push-confirm these with the sync server
+		 * before declaring the tree published — leaf file docs are tracked
+		 * separately, but intermediate folder docs exist only inside the shape.
+		 */
+		onDocChanged?: (url: AutomergeUrl) => void;
 	}): Promise<AutomergeUrl>;
 	decode(args: {
 		repo: Repo;

--- a/src/shapes/vfs.ts
+++ b/src/shapes/vfs.ts
@@ -29,7 +29,7 @@ const isDirectoryDoc = (doc: unknown): doc is DirectoryDoc => {
 const RESERVED = new Set([META, "lastSyncAt"]);
 
 export const vfsShape: Shape = {
-	async encode({ repo, tree, previousRoot, title }) {
+	async encode({ repo, tree, previousRoot, title, onDocChanged }) {
 		if (tree.kind !== "dir") throw new Error("vfs: root must be a dir");
 		const flat = flattenLeaves(tree);
 		dlog("encode keys=%d previousRoot=%s", flat.size, previousRoot?.url ?? "<new>");
@@ -52,6 +52,7 @@ export const vfsShape: Shape = {
 			}
 		});
 
+		onDocChanged?.(handle.url);
 		dlog("encode complete url=%s", handle.url);
 		return handle.url;
 	},

--- a/test/unit/sync-helpers.test.ts
+++ b/test/unit/sync-helpers.test.ts
@@ -131,19 +131,30 @@ function fakeRepo(init: {
 	shutdown?: () => Promise<void>;
 	connected?: boolean;
 	peerIds?: string[];
+	legacyPeers?: string[];
 }) {
 	let connected = init.connected ?? false;
+	const peers: string[] = [...(init.legacyPeers ?? [])];
 	const listeners = new Map<string, Set<Handler>>();
+	const addListener = (event: string, fn: Handler) => {
+		(listeners.get(event) ?? listeners.set(event, new Set()).get(event)!).add(fn);
+	};
+	const removeListener = (event: string, fn: Handler) => {
+		listeners.get(event)?.delete(fn);
+	};
 	const repo = {
 		shutdown: init.shutdown ?? (async () => {}),
 		isSubductionConnected: () => connected,
 		connectedSubductionPeerIds: async () => init.peerIds ?? [],
-		on: (event: string, fn: Handler) => {
-			(listeners.get(event) ?? listeners.set(event, new Set()).get(event)!).add(fn);
+		get peers() {
+			return peers;
 		},
-		off: (event: string, fn: Handler) => {
-			listeners.get(event)?.delete(fn);
+		networkSubsystem: {
+			on: (event: string, fn: Handler) => addListener(`net:${event}`, fn),
+			off: (event: string, fn: Handler) => removeListener(`net:${event}`, fn),
 		},
+		on: addListener,
+		off: removeListener,
 	};
 	return {
 		repo: repo as unknown as Repo,
@@ -153,8 +164,17 @@ function fakeRepo(init: {
 				fn({ connected: value });
 			}
 		},
+		emitPeer(peerId: string) {
+			peers.push(peerId);
+			for (const fn of listeners.get("net:peer") ?? []) {
+				fn({ peerId });
+			}
+		},
 		listenerCount() {
-			return listeners.get("subduction-connection")?.size ?? 0;
+			return (
+				(listeners.get("subduction-connection")?.size ?? 0) +
+				(listeners.get("net:peer")?.size ?? 0)
+			);
 		},
 	};
 }
@@ -193,12 +213,35 @@ describe("safeShutdown", () => {
 });
 
 describe("waitForConnection", () => {
-	it("short-circuits on the legacy backend (no Subduction source)", async () => {
-		const { repo } = fakeRepo({});
+	it("legacy: reports 0ms and the peer when already connected", async () => {
+		const { repo } = fakeRepo({ legacyPeers: ["legacy-server"] });
 		await expect(waitForConnection(repo, "legacy")).resolves.toEqual({
-			connected: false,
+			connected: true,
 			connectMs: 0,
+			serverPeerId: "legacy-server",
 		});
+	});
+
+	it("legacy: resolves when the peer event fires, timing the handshake", async () => {
+		const fake = fakeRepo({});
+		const p = waitForConnection(fake.repo, "legacy", { maxMs: 5000 });
+		setTimeout(() => fake.emitPeer("legacy-server"), 60);
+		const conn = await p;
+		expect(conn.connected).toBe(true);
+		expect(conn.serverPeerId).toBe("legacy-server");
+		expect(conn.connectMs).toBeGreaterThanOrEqual(40);
+		expect(conn.connectMs).toBeLessThan(2000);
+		expect(fake.listenerCount()).toBe(0);
+	});
+
+	it("legacy: gives up (connected=false) after maxMs without hanging", async () => {
+		const fake = fakeRepo({});
+		const start = Date.now();
+		const conn = await waitForConnection(fake.repo, "legacy", { maxMs: 120 });
+		expect(conn.connected).toBe(false);
+		expect(conn.serverPeerId).toBeUndefined();
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		expect(fake.listenerCount()).toBe(0);
 	});
 
 	it("reports 0ms and the server peer when already connected", async () => {


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add snarf paste command" — not "Added snarf...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For sync-protocol, document-shape, or config-format changes, link the
  relevant design doc in `design/` or call out where the discussion
  happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI, document shape, config format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. For sync or
delivery-path changes, note whether you clone-verified (init → clone →
byte-identical trees).
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Config-format changes need a CONFIG_VERSION bump
and a migration in src/migrations.ts. Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes (or relevant subset, with rationale)
- [ ] `pnpm typecheck` and `pnpm lint` are clean
- [ ] User-visible changes are reflected in `README.md` or the relevant `design/` doc
